### PR TITLE
Update parsing for AType:12 events

### DIFF
--- a/src/main/java/pwcg/aar/inmission/phase1/parse/event/bos/AType12.java
+++ b/src/main/java/pwcg/aar/inmission/phase1/parse/event/bos/AType12.java
@@ -52,7 +52,10 @@ public class AType12 extends ATypeBase implements IAType12
 
         name = getString(line, "NAME:", " PID:");
         
-        pid = getString(line, "PID:", null);
+        if (line.contains(" POS("))
+            pid = getString(line, "PID:", " POS(");
+        else
+            pid = getString(line, "PID:", null);
     }
 
     @Override


### PR DESCRIPTION
From some version of BoS the format of AType:12 events was updated to add a
position field. This meant that the PID was no longer parsed correctly
by PWCG, and so Bots weren't correctly associated with their planes.