### PR TITLE
Runway updates

### DIFF
--- a/src/main/java/pwcg/campaign/api/IAirfield.java
+++ b/src/main/java/pwcg/campaign/api/IAirfield.java
@@ -40,6 +40,8 @@ public interface IAirfield extends IFixedPosition
     public Coordinate getPosition();
 
     public PWCGLocation getPlanePosition() throws PWCGException;
+
+    public PWCGLocation getLandingLocation() throws PWCGException;
     
     public Date getStartDate();
 }

--- a/src/main/java/pwcg/campaign/api/IAirfield.java
+++ b/src/main/java/pwcg/campaign/api/IAirfield.java
@@ -35,10 +35,26 @@ public interface IAirfield extends IFixedPosition
 
     public String getScript();
     
+    /**
+     * Gets the location of the airfield as a whole, used for map coordinates,
+     * distance checking etc. Does not relate to takeoff/landing locations.
+     */
     public Coordinate getPosition();
 
+    /**
+     * Gets the position and direction for the start of the takeoff run from
+     * this airfield.
+     * @return Takeoff position and orientation
+     * @throws PWCGException
+     */
     public PWCGLocation getTakeoffLocation() throws PWCGException;
 
+    /**
+     * Gets the position and direction for the touchdown point when landing at
+     * this airfield.
+     * @return Landing position and orientation
+     * @throws PWCGException
+     */
     public PWCGLocation getLandingLocation() throws PWCGException;
     
     public Date getStartDate();

--- a/src/main/java/pwcg/campaign/api/IAirfield.java
+++ b/src/main/java/pwcg/campaign/api/IAirfield.java
@@ -57,5 +57,7 @@ public interface IAirfield extends IFixedPosition
      */
     public PWCGLocation getLandingLocation() throws PWCGException;
     
+    public boolean isNearRunwayOrTaxiway(Coordinate pos) throws PWCGException;
+
     public Date getStartDate();
 }

--- a/src/main/java/pwcg/campaign/api/IAirfield.java
+++ b/src/main/java/pwcg/campaign/api/IAirfield.java
@@ -35,11 +35,9 @@ public interface IAirfield extends IFixedPosition
 
     public String getScript();
     
-    public double getPlaneOrientation();
-    
     public Coordinate getPosition();
 
-    public PWCGLocation getPlanePosition() throws PWCGException;
+    public PWCGLocation getTakeoffLocation() throws PWCGException;
 
     public PWCGLocation getLandingLocation() throws PWCGException;
     

--- a/src/main/java/pwcg/campaign/group/EmptySpaceFinder.java
+++ b/src/main/java/pwcg/campaign/group/EmptySpaceFinder.java
@@ -87,17 +87,8 @@ public class EmptySpaceFinder
     {
         for (IAirfield airfield : airfieldsInArea)
         {
-            double runwayOrientation = airfield.getTakeoffLocation().getOrientation().getyOri();
-            Coordinate startOfRunway = airfield.getTakeoffLocation().getPosition().copy();
-            Coordinate endOfRunway = MathUtils.calcNextCoord(airfield.getTakeoffLocation().getPosition(), runwayOrientation, 2000.0);
-            
-            CoordinateBox runwayCoordinateBox = CoordinateBox.coordinateBoxFromTwoCoordinates(startOfRunway, endOfRunway);
-            runwayCoordinateBox.expandBox(200);
-            
-            if (runwayCoordinateBox.isInBox(coordinateExaminedNow))
-            {
+            if (airfield.isNearRunwayOrTaxiway(coordinateExaminedNow))
                 return true;
-            }
         }
 
         return false;

--- a/src/main/java/pwcg/campaign/group/EmptySpaceFinder.java
+++ b/src/main/java/pwcg/campaign/group/EmptySpaceFinder.java
@@ -87,9 +87,9 @@ public class EmptySpaceFinder
     {
         for (IAirfield airfield : airfieldsInArea)
         {
-            double runwayOrientation = airfield.getPlanePosition().getOrientation().getyOri();
-            Coordinate startOfRunway = airfield.getPlanePosition().getPosition().copy();
-            Coordinate endOfRunway = MathUtils.calcNextCoord(airfield.getPlanePosition().getPosition(), runwayOrientation, 2000.0);
+            double runwayOrientation = airfield.getTakeoffLocation().getOrientation().getyOri();
+            Coordinate startOfRunway = airfield.getTakeoffLocation().getPosition().copy();
+            Coordinate endOfRunway = MathUtils.calcNextCoord(airfield.getTakeoffLocation().getPosition(), runwayOrientation, 2000.0);
             
             CoordinateBox runwayCoordinateBox = CoordinateBox.coordinateBoxFromTwoCoordinates(startOfRunway, endOfRunway);
             runwayCoordinateBox.expandBox(200);

--- a/src/main/java/pwcg/campaign/ww1/airfield/RoFAirfield.java
+++ b/src/main/java/pwcg/campaign/ww1/airfield/RoFAirfield.java
@@ -16,6 +16,7 @@ import pwcg.core.config.ConfigItemKeys;
 import pwcg.core.exception.PWCGException;
 import pwcg.core.exception.PWCGIOException;
 import pwcg.core.location.Coordinate;
+import pwcg.core.location.CoordinateBox;
 import pwcg.core.location.Orientation;
 import pwcg.core.location.PWCGLocation;
 import pwcg.core.utils.Logger;
@@ -242,5 +243,17 @@ public class RoFAirfield extends FixedPosition implements IAirfield, Cloneable
 	@Override
 	public PWCGLocation getTakeoffLocation() throws PWCGException {
 		return this;
+	}
+
+	@Override
+	public boolean isNearRunwayOrTaxiway(Coordinate pos) throws PWCGException {
+		double runwayOrientation = getTakeoffLocation().getOrientation().getyOri();
+		Coordinate startOfRunway = getTakeoffLocation().getPosition();
+		Coordinate endOfRunway = MathUtils.calcNextCoord(getTakeoffLocation().getPosition(), runwayOrientation, 2000.0);
+
+		CoordinateBox runwayCoordinateBox = CoordinateBox.coordinateBoxFromTwoCoordinates(startOfRunway, endOfRunway);
+		runwayCoordinateBox.expandBox(200);
+
+		return runwayCoordinateBox.isInBox(pos);
 	}
 }

--- a/src/main/java/pwcg/campaign/ww1/airfield/RoFAirfield.java
+++ b/src/main/java/pwcg/campaign/ww1/airfield/RoFAirfield.java
@@ -125,7 +125,7 @@ public class RoFAirfield extends FixedPosition implements IAirfield, Cloneable
 	    }
 	}
 
-    public double getPlaneOrientation() 
+    private double getPlaneOrientation()
     {
         if (orientation != null)
         {
@@ -161,12 +161,6 @@ public class RoFAirfield extends FixedPosition implements IAirfield, Cloneable
     public void initializeAirfieldFromLocation(PWCGLocation airfieldLocation)
     {
         super.setFromLocation(airfieldLocation);
-    }
-        
-    @Override
-    public PWCGLocation getPlanePosition()
-    {
-        return this;
     }
 
 	@Override
@@ -236,12 +230,17 @@ public class RoFAirfield extends FixedPosition implements IAirfield, Cloneable
 		Campaign campaign = PWCGContextManager.getInstance().getCampaign();
 		int landingDistance = campaign.getCampaignConfigManager().getIntConfigParam(ConfigItemKeys.LandingDistanceKey);
 		Coordinate landCoords = MathUtils.calcNextCoord(
-				getPlanePosition().getPosition(),
+				getPosition(),
 				getPlaneOrientation(),
 				landingDistance);
 		landCoords.setYPos(0.0);
 		location.setPosition(landCoords);
 
 		return location;
+	}
+
+	@Override
+	public PWCGLocation getTakeoffLocation() throws PWCGException {
+		return this;
 	}
 }

--- a/src/main/java/pwcg/campaign/ww1/airfield/RoFAirfield.java
+++ b/src/main/java/pwcg/campaign/ww1/airfield/RoFAirfield.java
@@ -8,15 +8,18 @@ import pwcg.campaign.Campaign;
 import pwcg.campaign.api.IAirfield;
 import pwcg.campaign.api.ICountry;
 import pwcg.campaign.api.IStaticPlane;
+import pwcg.campaign.context.PWCGContextManager;
 import pwcg.campaign.group.FixedPosition;
 import pwcg.campaign.group.airfield.AirfieldObjectPlacer;
 import pwcg.campaign.group.airfield.AirfieldObjects;
+import pwcg.core.config.ConfigItemKeys;
 import pwcg.core.exception.PWCGException;
 import pwcg.core.exception.PWCGIOException;
 import pwcg.core.location.Coordinate;
 import pwcg.core.location.Orientation;
 import pwcg.core.location.PWCGLocation;
 import pwcg.core.utils.Logger;
+import pwcg.core.utils.MathUtils;
 import pwcg.mission.ground.unittypes.GroundUnitSpawning;
 import pwcg.mission.ground.vehicle.IVehicle;
 import pwcg.mission.mcu.McuTREntity;
@@ -222,5 +225,23 @@ public class RoFAirfield extends FixedPosition implements IAirfield, Cloneable
 	public ICountry getCountry(Date date) throws PWCGException
 	{
 		return airfieldFixedPosition.getCountry(date);
+	}
+
+	@Override
+	public PWCGLocation getLandingLocation() throws PWCGException
+	{
+		PWCGLocation location = new PWCGLocation();
+		location.getOrientation().setyOri(getPlaneOrientation() - 180);
+
+		Campaign campaign = PWCGContextManager.getInstance().getCampaign();
+		int landingDistance = campaign.getCampaignConfigManager().getIntConfigParam(ConfigItemKeys.LandingDistanceKey);
+		Coordinate landCoords = MathUtils.calcNextCoord(
+				getPlanePosition().getPosition(),
+				getPlaneOrientation(),
+				landingDistance);
+		landCoords.setYPos(0.0);
+		location.setPosition(landCoords);
+
+		return location;
 	}
 }

--- a/src/main/java/pwcg/campaign/ww2/airfield/BoSAirfield.java
+++ b/src/main/java/pwcg/campaign/ww2/airfield/BoSAirfield.java
@@ -151,8 +151,7 @@ public class BoSAirfield extends FixedPosition implements IAirfield, Cloneable
         return null;
     }
 
-    @Override
-    public PWCGLocation getPlanePosition() throws PWCGException
+    private PWCGLocation getRunwayStart() throws PWCGException
     {
 		Runway runway = selectRunway();
 
@@ -169,8 +168,13 @@ public class BoSAirfield extends FixedPosition implements IAirfield, Cloneable
     }
         
 	@Override
+	public PWCGLocation getTakeoffLocation() throws PWCGException {
+		return getRunwayStart();
+	}
+
+	@Override
 	public PWCGLocation getLandingLocation() throws PWCGException {
-		return getPlanePosition();
+		return getRunwayStart();
 	}
 
 	// TODO: Select runway based on wind direction
@@ -187,7 +191,7 @@ public class BoSAirfield extends FixedPosition implements IAirfield, Cloneable
 		double xpos = point.getXPos() - getPosition().getXPos();
 		double ypos = point.getZPos() - getPosition().getZPos();
 
-		double angle = Math.toRadians(-this.getPlaneOrientation());
+		double angle = Math.toRadians(-orientation.getyOri());
 
 		double rxpos = Math.cos(angle) * xpos - Math.sin(angle) * ypos;
 		double rypos = Math.cos(angle) * ypos + Math.sin(angle) * xpos;

--- a/src/main/java/pwcg/campaign/ww2/airfield/BoSAirfield.java
+++ b/src/main/java/pwcg/campaign/ww2/airfield/BoSAirfield.java
@@ -168,6 +168,11 @@ public class BoSAirfield extends FixedPosition implements IAirfield, Cloneable
 		}
     }
         
+	@Override
+	public PWCGLocation getLandingLocation() throws PWCGException {
+		return getPlanePosition();
+	}
+
 	// TODO: Select runway based on wind direction
 	private Runway selectRunway()
 	{

--- a/src/main/java/pwcg/campaign/ww2/ground/vehicle/RadioBeacon.java
+++ b/src/main/java/pwcg/campaign/ww2/ground/vehicle/RadioBeacon.java
@@ -38,7 +38,7 @@ class RadioBeacon extends Vehicle implements IVehicle
 
     public void initialize(Flight flight) throws PWCGException 
     {
-        double airfieldOrientation = flight.getAirfield().getOrientation().getyOri();
+        double airfieldOrientation = flight.getAirfield().getTakeoffLocation().getOrientation().getyOri();
 
         Coordinate RadioBeaconCoordMoveLeft = moveWindSockDownAndLeftOfRunway(flight, airfieldOrientation);
 
@@ -57,7 +57,7 @@ class RadioBeacon extends Vehicle implements IVehicle
         Campaign campaign = PWCGContextManager.getInstance().getCampaign();
         ConfigManager configManager = campaign.getCampaignConfigManager();
         int RadioBeaconDistance = configManager.getIntConfigParam(ConfigItemKeys.WindsockDistanceKey);
-        Coordinate RadioBeaconCoordMoveLeft = MathUtils.calcNextCoord(flight.getAirfield().getPosition().copy(), angleRadioBeaconLeft, RadioBeaconDistance);
+        Coordinate RadioBeaconCoordMoveLeft = MathUtils.calcNextCoord(flight.getAirfield().getTakeoffLocation().getPosition().copy(), angleRadioBeaconLeft, RadioBeaconDistance);
 		return RadioBeaconCoordMoveLeft;
 	}
 	

--- a/src/main/java/pwcg/core/utils/MathUtils.java
+++ b/src/main/java/pwcg/core/utils/MathUtils.java
@@ -218,4 +218,23 @@ public class MathUtils
         numberToBinaryFormCalculator(binaryRepresentation, shifterNumber);
     	binaryRepresentation.append(remainder);
     }
+
+    public static double distFromLine(final Coordinate lineStart, final Coordinate lineEnd, final Coordinate coord) throws PWCGException
+    {
+        double xDist = lineEnd.getXPos() - lineStart.getXPos();
+        double zDist = lineEnd.getZPos() - lineStart.getZPos();
+        double distSquared = xDist * xDist + zDist * zDist;
+
+        if (distSquared == 0)
+            return calcDist(lineStart, coord);
+
+        double t = ((coord.getXPos() - lineStart.getXPos()) * xDist + (coord.getZPos() - lineStart.getZPos()) * zDist) / distSquared;
+        t = Math.max(0, Math.min(1,  t));
+
+        Coordinate proj = new Coordinate();
+        proj.setXPos(lineStart.getXPos() + t * xDist);
+        proj.setZPos(lineStart.getZPos() + t * zDist);
+
+        return calcDist(proj, coord);
+    }
 }

--- a/src/main/java/pwcg/mission/FirePotBuilder.java
+++ b/src/main/java/pwcg/mission/FirePotBuilder.java
@@ -3,6 +3,7 @@ package pwcg.mission;
 import pwcg.campaign.api.IAirfield;
 import pwcg.core.exception.PWCGException;
 import pwcg.core.location.Coordinate;
+import pwcg.core.location.PWCGLocation;
 import pwcg.core.utils.MathUtils;
 import pwcg.mission.mcu.effect.FirePotSeries;
 
@@ -12,8 +13,9 @@ public class FirePotBuilder
     {
         FirePotSeries firePotSeries = new FirePotSeries();
 
-        double airfieldOrientation = airfield.getPlaneOrientation();
-        Coordinate planePosition = airfield.getPlanePosition().getPosition().copy();
+        PWCGLocation takeoffLocation = airfield.getTakeoffLocation();
+        double airfieldOrientation = takeoffLocation.getOrientation().getyOri();
+        Coordinate planePosition = takeoffLocation.getPosition().copy();
 
         Double angleOffsetFirePots = MathUtils.adjustAngle(airfieldOrientation, -90);
         Coordinate positionLeftOfPlane = MathUtils.calcNextCoord(planePosition, angleOffsetFirePots, 30.0);

--- a/src/main/java/pwcg/mission/Mission.java
+++ b/src/main/java/pwcg/mission/Mission.java
@@ -64,6 +64,8 @@ public class Mission
 
     public void generate(FlightTypes flightType) throws PWCGException 
     {
+        PWCGContextManager.getInstance().getCurrentMap().getMapWeather().createWindDirection();
+
     	missionFlightBuilder.generateFlights(flightType);
 
         createFirePots();

--- a/src/main/java/pwcg/mission/flight/Flight.java
+++ b/src/main/java/pwcg/mission/flight/Flight.java
@@ -210,7 +210,7 @@ public abstract class Flight extends Unit
 
     private void createWaypoints() throws PWCGException
     {
-        Coordinate startPosition = departureAirfield.getPlanePosition().getPosition().copy();
+        Coordinate startPosition = departureAirfield.getTakeoffLocation().getPosition().copy();
         List<McuWaypoint> waypointList = createWaypoints(mission, startPosition);
         waypointPackage.setWaypoints(waypointList);
     }

--- a/src/main/java/pwcg/mission/flight/Flight.java
+++ b/src/main/java/pwcg/mission/flight/Flight.java
@@ -424,12 +424,13 @@ public abstract class Flight extends Unit
 
     /**
      * Takeoff for player plane
+     * @throws PWCGException
      */
-    public void createTakeoff()
+    public void createTakeoff() throws PWCGException
     {
         takeoff = new McuTakeoff();
-        takeoff.setPosition(departureAirfield.getPosition().copy());
-        takeoff.setOrientation(departureAirfield.getOrientation().copy());
+        takeoff.setPosition(departureAirfield.getTakeoffLocation().getPosition().copy());
+        takeoff.setOrientation(departureAirfield.getTakeoffLocation().getOrientation().copy());
     }
 
 

--- a/src/main/java/pwcg/mission/flight/FlightPositionHelperPlayerStart.java
+++ b/src/main/java/pwcg/mission/flight/FlightPositionHelperPlayerStart.java
@@ -46,7 +46,7 @@ public class FlightPositionHelperPlayerStart
         {
             plane.setPosition(takeOffPositions.get(plane.getNumberInFormation()-1));
 
-            Orientation orient = flight.getDepartureAirfield().getOrientation().copy();
+            Orientation orient = flight.getDepartureAirfield().getTakeoffLocation().getOrientation().copy();
             plane.setOrientation(orient);
 
             plane.populateEntity(flight, flightLeader);

--- a/src/main/java/pwcg/mission/flight/FlightPositionHelperPlayerStart.java
+++ b/src/main/java/pwcg/mission/flight/FlightPositionHelperPlayerStart.java
@@ -46,8 +46,7 @@ public class FlightPositionHelperPlayerStart
         {
             plane.setPosition(takeOffPositions.get(plane.getNumberInFormation()-1));
 
-            Orientation orient = new Orientation();
-            orient.setyOri(flight.getDepartureAirfield().getPlaneOrientation());
+            Orientation orient = flight.getDepartureAirfield().getOrientation().copy();
             plane.setOrientation(orient);
 
             plane.populateEntity(flight, flightLeader);
@@ -63,7 +62,7 @@ public class FlightPositionHelperPlayerStart
         Coordinate firstDestinationCoordinate = flight.findFirstWaypointPosition();
 
         // Calculate plane position about 5 KM from the first destination
-        double angleBetweenBaseAndFirstDest = MathUtils.calcAngle(flight.getDepartureAirfield().getPlanePosition().getPosition().copy(), firstDestinationCoordinate);
+        double angleBetweenBaseAndFirstDest = MathUtils.calcAngle(flight.getDepartureAirfield().getTakeoffLocation().getPosition().copy(), firstDestinationCoordinate);
         double angleToPlacePlanes = MathUtils.adjustAngle(angleBetweenBaseAndFirstDest, 180);
         
         Coordinate startCoordinate = MathUtils.calcNextCoord(firstDestinationCoordinate, angleToPlacePlanes, 5000);

--- a/src/main/java/pwcg/mission/flight/LandingBuilder.java
+++ b/src/main/java/pwcg/mission/flight/LandingBuilder.java
@@ -2,11 +2,8 @@ package pwcg.mission.flight;
 
 import pwcg.campaign.Campaign;
 import pwcg.campaign.api.IAirfield;
-import pwcg.core.config.ConfigItemKeys;
 import pwcg.core.exception.PWCGException;
-import pwcg.core.location.Coordinate;
-import pwcg.core.location.Orientation;
-import pwcg.core.utils.MathUtils;
+import pwcg.core.location.PWCGLocation;
 import pwcg.mission.mcu.McuLanding;
 
 public class LandingBuilder
@@ -20,37 +17,15 @@ public class LandingBuilder
     
     public McuLanding createLanding(IAirfield airfield) throws PWCGException, PWCGException  
     {
-        Orientation landingOrientation = createLandingOrientation(airfield);
-        Coordinate landCoords = createLandingPosition(airfield, landingOrientation);
+        PWCGLocation location = airfield.getLandingLocation();
         
         McuLanding landing = new McuLanding();
         landing.setDesc("Land");
         landing.setName("Land");
-        landing.setPosition(landCoords);        
-        landing.setOrientation(landingOrientation);
+        landing.setPosition(location.getPosition());
+        landing.setOrientation(location.getOrientation());
         
         return landing;
     }
-
-    private Orientation createLandingOrientation(IAirfield airfield) throws PWCGException
-    {
-        Orientation landingOrientation = new Orientation();
-        landingOrientation.setyOri(airfield.getPlaneOrientation() - 180);
-        return landingOrientation;
-    }
-
-    private Coordinate createLandingPosition(IAirfield airfield, Orientation landingOrientation) throws PWCGException, PWCGException
-    {
-        int landingDistance = campaign.getCampaignConfigManager().getIntConfigParam(ConfigItemKeys.LandingDistanceKey);
-        Coordinate landCoords = MathUtils.calcNextCoord(
-                airfield.getPlanePosition().getPosition(), 
-                airfield.getPlaneOrientation(), 
-                landingDistance);
-        
-        landCoords.setYPos(0.0);
-
-        return landCoords;
-    }
-
 
 }

--- a/src/main/java/pwcg/mission/flight/RunwayPlacerLineAbreast.java
+++ b/src/main/java/pwcg/mission/flight/RunwayPlacerLineAbreast.java
@@ -7,6 +7,7 @@ import java.util.List;
 import pwcg.campaign.api.IAirfield;
 import pwcg.core.exception.PWCGException;
 import pwcg.core.location.Coordinate;
+import pwcg.core.location.PWCGLocation;
 import pwcg.core.utils.MathUtils;
 
 public class RunwayPlacerLineAbreast implements IRunwayPlacer
@@ -27,8 +28,9 @@ public class RunwayPlacerLineAbreast implements IRunwayPlacer
     {
         List<Coordinate> takeOffPositions = new ArrayList<>();
          
-        Coordinate fieldPlanePosition = airfield.getPlanePosition().getPosition().copy();
-        double lineAbreastAngle = calculateLineAbreastAngle();
+        PWCGLocation takeoffLocation = airfield.getTakeoffLocation();
+        Coordinate fieldPlanePosition = takeoffLocation.getPosition().copy();
+        double lineAbreastAngle = calculateLineAbreastAngle(takeoffLocation);
         for (int i = 0; i < flight.getPlanes().size(); ++i)
         {
             Coordinate takeoffCoordsForPlane = MathUtils.calcNextCoord(fieldPlanePosition, lineAbreastAngle, (takeoffSpacing * i));
@@ -40,9 +42,9 @@ public class RunwayPlacerLineAbreast implements IRunwayPlacer
         return takeOffPositions;
     }
     
-    private double calculateLineAbreastAngle()
+    private double calculateLineAbreastAngle(PWCGLocation loc)
     {
-        double takeoffAngle = airfield.getPlaneOrientation();
+        double takeoffAngle = loc.getOrientation().getyOri();
         double lineAbreastAngle = MathUtils.adjustAngle(takeoffAngle, 90);
         return lineAbreastAngle;
     }

--- a/src/main/java/pwcg/mission/flight/RunwayPlacerLineAstern.java
+++ b/src/main/java/pwcg/mission/flight/RunwayPlacerLineAstern.java
@@ -26,8 +26,8 @@ public class RunwayPlacerLineAstern implements IRunwayPlacer
     {
         List<Coordinate> takeOffPositions = new ArrayList<>();
                 
-        Coordinate fieldPlanePosition = airfield.getPlanePosition().getPosition().copy();
-        double fieldPlaneOrientation = airfield.getPlaneOrientation();
+        Coordinate fieldPlanePosition = airfield.getTakeoffLocation().getPosition().copy();
+        double fieldPlaneOrientation = airfield.getTakeoffLocation().getOrientation().getyOri();
         for (int i = 0; i < flight.getPlanes().size(); ++i)
         {
             Coordinate takeoffCoordsForPlane = MathUtils.calcNextCoord(fieldPlanePosition, fieldPlaneOrientation, (takeoffSpacing * i));

--- a/src/main/java/pwcg/mission/flight/RunwayPlacerStaggered.java
+++ b/src/main/java/pwcg/mission/flight/RunwayPlacerStaggered.java
@@ -57,17 +57,17 @@ public class RunwayPlacerStaggered implements IRunwayPlacer
     
     private Coordinate calculateInitialPlacement() throws PWCGException
     {
-        double takeoffAngle = airfield.getPlaneOrientation();
+        double takeoffAngle = airfield.getTakeoffLocation().getOrientation().getyOri();
         double initialPlacementAngleAngle = MathUtils.adjustAngle(takeoffAngle, 270);
 
-        Coordinate fieldPlanePosition = airfield.getPlanePosition().getPosition().copy();
+        Coordinate fieldPlanePosition = airfield.getTakeoffLocation().getPosition().copy();
         Coordinate initialCoord = MathUtils.calcNextCoord(fieldPlanePosition, initialPlacementAngleAngle, (25.0));
         return initialCoord;
     }
     
     private Coordinate calculateNextRight(Coordinate lastPosition, int takeoffSpacing) throws PWCGException
     {
-        double takeoffAngle = airfield.getPlaneOrientation();
+        double takeoffAngle = airfield.getTakeoffLocation().getOrientation().getyOri();
         double nextlacementAngleAngle = MathUtils.adjustAngle(takeoffAngle, 45);
 
         Coordinate nextTakeoffCoord = MathUtils.calcNextCoord(lastPosition, nextlacementAngleAngle, (takeoffSpacing));
@@ -76,7 +76,7 @@ public class RunwayPlacerStaggered implements IRunwayPlacer
     
     private Coordinate calculateNextLeft(Coordinate lastPosition, int takeoffSpacing) throws PWCGException
     {
-        double takeoffAngle = airfield.getPlaneOrientation();
+        double takeoffAngle = airfield.getTakeoffLocation().getOrientation().getyOri();
         double nextlacementAngleAngle = MathUtils.adjustAngle(takeoffAngle, 315);
 
         Coordinate nextTakeoffCoord = MathUtils.calcNextCoord(lastPosition, nextlacementAngleAngle, (takeoffSpacing));

--- a/src/main/java/pwcg/mission/flight/factory/FerryWaypoints.java
+++ b/src/main/java/pwcg/mission/flight/factory/FerryWaypoints.java
@@ -40,9 +40,9 @@ public class FerryWaypoints extends WaypointGeneratorBase
 
     protected void createStartWaypoint() throws PWCGException  
     {
-        double airfieldOrientation = fromAirfield.getOrientation().getyOri();
+        double takeoffOrientation = fromAirfield.getTakeoffLocation().getOrientation().getyOri();
         int InitialWaypointDistance = campaign.getCampaignConfigManager().getIntConfigParam(ConfigItemKeys.InitialWaypointDistanceKey);
-        startCoords = MathUtils.calcNextCoord(fromAirfield.getPosition().copy(), airfieldOrientation, InitialWaypointDistance);
+        startCoords = MathUtils.calcNextCoord(fromAirfield.getTakeoffLocation().getPosition().copy(), takeoffOrientation, InitialWaypointDistance);
         int InitialWaypointAltitude = campaign.getCampaignConfigManager().getIntConfigParam(ConfigItemKeys.InitialWaypointAltitudeKey);
         startCoords.setYPos(InitialWaypointAltitude);
 

--- a/src/main/java/pwcg/mission/flight/ferry/FerryWaypoints.java
+++ b/src/main/java/pwcg/mission/flight/ferry/FerryWaypoints.java
@@ -40,9 +40,9 @@ public class FerryWaypoints extends WaypointGeneratorBase
 
     protected void createStartWaypoint() throws PWCGException  
     {
-        double airfieldOrientation = fromAirfield.getOrientation().getyOri();
+        double takeoffOrientation = fromAirfield.getTakeoffLocation().getOrientation().getyOri();
         int InitialWaypointDistance = campaign.getCampaignConfigManager().getIntConfigParam(ConfigItemKeys.InitialWaypointDistanceKey);
-        startCoords = MathUtils.calcNextCoord(fromAirfield.getPosition().copy(), airfieldOrientation, InitialWaypointDistance);
+        startCoords = MathUtils.calcNextCoord(fromAirfield.getTakeoffLocation().getPosition().copy(), takeoffOrientation, InitialWaypointDistance);
         int InitialWaypointAltitude = campaign.getCampaignConfigManager().getIntConfigParam(ConfigItemKeys.InitialWaypointAltitudeKey);
         startCoords.setYPos(InitialWaypointAltitude);
 

--- a/src/main/java/pwcg/mission/flight/scramble/ScrambleWaypoints.java
+++ b/src/main/java/pwcg/mission/flight/scramble/ScrambleWaypoints.java
@@ -44,9 +44,9 @@ public class ScrambleWaypoints
 	
 	protected void createStartWaypoint() throws PWCGException  
 	{
-		double airfieldOrientation = flight.getAirfield().getOrientation().getyOri();
+		double takeoffOrientation = flight.getAirfield().getTakeoffLocation().getOrientation().getyOri();
 		int InitialWaypointDistance = flight.getCampaign().getCampaignConfigManager().getIntConfigParam(ConfigItemKeys.InitialWaypointDistanceKey);
-		startCoords = MathUtils.calcNextCoord(flight.getAirfield().getPosition().copy(), airfieldOrientation, InitialWaypointDistance);
+		startCoords = MathUtils.calcNextCoord(flight.getAirfield().getTakeoffLocation().getPosition().copy(), takeoffOrientation, InitialWaypointDistance);
 
 		int InitialWaypointAltitude = flight.getCampaign().getCampaignConfigManager().getIntConfigParam(ConfigItemKeys.InitialWaypointAltitudeKey);
 		startCoords.setYPos(InitialWaypointAltitude);

--- a/src/main/java/pwcg/mission/flight/transport/TransportWaypoints.java
+++ b/src/main/java/pwcg/mission/flight/transport/TransportWaypoints.java
@@ -46,10 +46,10 @@ public class TransportWaypoints extends WaypointGeneratorBase
 
     protected void createStartWaypoint() throws PWCGException  
     {
-        double airfieldOrientation = fromAirfield.getOrientation().getyOri();
+        double takeoffOrientation = fromAirfield.getTakeoffLocation().getOrientation().getyOri();
         int initialWaypointDistance = campaign.getCampaignConfigManager().getIntConfigParam(ConfigItemKeys.InitialWaypointDistanceKey);
         
-        startCoords = MathUtils.calcNextCoord(fromAirfield.getPosition().copy(), airfieldOrientation, initialWaypointDistance);
+        startCoords = MathUtils.calcNextCoord(fromAirfield.getTakeoffLocation().getPosition().copy(), takeoffOrientation, initialWaypointDistance);
         int InitialWaypointAltitude = campaign.getCampaignConfigManager().getIntConfigParam(ConfigItemKeys.InitialWaypointAltitudeKey);
         startCoords.setYPos(InitialWaypointAltitude);
 

--- a/src/main/java/pwcg/mission/flight/transport/TransportWaypoints.java
+++ b/src/main/java/pwcg/mission/flight/transport/TransportWaypoints.java
@@ -64,11 +64,11 @@ public class TransportWaypoints extends WaypointGeneratorBase
     protected void createMidWaypoint() throws PWCGException  
     {
         McuWaypoint lastWp = waypoints.get(waypoints.size()-1);
-        double angleFromTargetToHomeAirfield = MathUtils.calcAngle(lastWp.getPosition(), toAirfield.getPlanePosition().getPosition());
-        double distanceBetweenAirfields = MathUtils.calcDist(fromAirfield.getPlanePosition().getPosition(), toAirfield.getPlanePosition().getPosition());
+        double angleFromTargetToHomeAirfield = MathUtils.calcAngle(lastWp.getPosition(), toAirfield.getLandingLocation().getPosition());
+        double distanceBetweenAirfields = MathUtils.calcDist(fromAirfield.getTakeoffLocation().getPosition(), toAirfield.getLandingLocation().getPosition());
         distanceBetweenAirfields = distanceBetweenAirfields / 2;
         
-        Coordinate midPointCoords = MathUtils.calcNextCoord(fromAirfield.getPlanePosition().getPosition(), angleFromTargetToHomeAirfield, distanceBetweenAirfields);
+        Coordinate midPointCoords = MathUtils.calcNextCoord(fromAirfield.getTakeoffLocation().getPosition(), angleFromTargetToHomeAirfield, distanceBetweenAirfields);
         midPointCoords.setYPos(determineFlightAltitude());
 
         McuWaypoint midPointWP = WaypointFactory.createMoveToWaypointType();
@@ -82,9 +82,9 @@ public class TransportWaypoints extends WaypointGeneratorBase
 	protected void createDestinationWaypoint() throws PWCGException  
 	{
 	    McuWaypoint lastWp = waypoints.get(waypoints.size()-1);
-        double angleFromTargetToHomeAirfield = MathUtils.calcAngle(toAirfield.getPlanePosition().getPosition(), lastWp.getPosition());
+        double angleFromTargetToHomeAirfield = MathUtils.calcAngle(toAirfield.getLandingLocation().getPosition(), lastWp.getPosition());
         
-        Coordinate destinationCoords = MathUtils.calcNextCoord(toAirfield.getPlanePosition().getPosition(), angleFromTargetToHomeAirfield, 10000.0);
+        Coordinate destinationCoords = MathUtils.calcNextCoord(toAirfield.getLandingLocation().getPosition(), angleFromTargetToHomeAirfield, 10000.0);
         destinationCoords.setYPos(determineFlightAltitude());
 
         McuWaypoint destinationWP = WaypointFactory.createMoveToWaypointType();

--- a/src/main/java/pwcg/mission/flight/waypoint/ClimbWaypointGenerator.java
+++ b/src/main/java/pwcg/mission/flight/waypoint/ClimbWaypointGenerator.java
@@ -137,7 +137,7 @@ public class ClimbWaypointGenerator
         clearTheDeckClimbWP.setSpeed(waypointSpeed - 20);
         clearTheDeckClimbWP.setPriority(WaypointPriority.PRIORITY_HIGH);          
         clearTheDeckClimbWP.setPosition(initialClimbCoords);
-        clearTheDeckClimbWP.setOrientation(flight.getAirfield().getOrientation().copy());
+        clearTheDeckClimbWP.setOrientation(flight.getAirfield().getTakeoffLocation().getOrientation().copy());
 
         return clearTheDeckClimbWP;
     }
@@ -148,8 +148,8 @@ public class ClimbWaypointGenerator
         int takeoffWaypointDistance = campaign.getCampaignConfigManager().getIntConfigParam(ConfigItemKeys.TakeoffWaypointDistanceKey);
         int takeoffWaypointAltitude = campaign.getCampaignConfigManager().getIntConfigParam(ConfigItemKeys.TakeoffWaypointAltitudeKey);
 
-        double airfieldOrientation = flight.getAirfield().getOrientation().getyOri();
-        Coordinate initialClimbCoords = MathUtils.calcNextCoord(flight.getAirfield().getPosition().copy(), airfieldOrientation, takeoffWaypointDistance);
+        double takeoffOrientation = flight.getAirfield().getTakeoffLocation().getOrientation().getyOri();
+        Coordinate initialClimbCoords = MathUtils.calcNextCoord(flight.getAirfield().getTakeoffLocation().getPosition().copy(), takeoffOrientation, takeoffWaypointDistance);
         initialClimbCoords.setYPos(takeoffWaypointAltitude);
 		return initialClimbCoords;
 	}

--- a/src/main/java/pwcg/mission/flight/waypoint/WaypointGeneratorBase.java
+++ b/src/main/java/pwcg/mission/flight/waypoint/WaypointGeneratorBase.java
@@ -17,6 +17,7 @@ import pwcg.core.config.ConfigItemKeys;
 import pwcg.core.exception.PWCGException;
 import pwcg.core.location.Coordinate;
 import pwcg.core.location.Orientation;
+import pwcg.core.location.PWCGLocation;
 import pwcg.core.utils.Logger;
 import pwcg.core.utils.Logger.LogLevel;
 import pwcg.core.utils.MathUtils;
@@ -168,14 +169,15 @@ public abstract class WaypointGeneratorBase
 
 	protected void createApproachWaypoint(IAirfield airfield) throws PWCGException  
 	{
+		PWCGLocation landingLocation = airfield.getLandingLocation();
         int initialWaypointDistance = campaign.getCampaignConfigManager().getIntConfigParam(ConfigItemKeys.InitialWaypointDistanceKey);
-	    Coordinate approachCoords = MathUtils.calcNextCoord(airfield.getPosition(), airfield.getPlaneOrientation(), initialWaypointDistance);
+	    Coordinate approachCoords = MathUtils.calcNextCoord(landingLocation.getPosition(), landingLocation.getOrientation().getyOri() - 180, initialWaypointDistance);
 		
 		int ApproachWaypointAltitude = campaign.getCampaignConfigManager().getIntConfigParam(ConfigItemKeys.ApproachWaypointAltitudeKey);
 		approachCoords.setYPos(airfield.getPosition().getYPos() + ApproachWaypointAltitude);
 
 		Orientation orient = new Orientation();
-		orient.setyOri(airfield.getOrientation().getyOri() - 180);
+		orient.setyOri(landingLocation.getOrientation().getyOri());
 
 		McuWaypoint approachWP = WaypointFactory.createLandingApproachWaypointType();
 		approachWP.setTriggerArea(McuWaypoint.LAND_AREA);

--- a/src/main/java/pwcg/mission/object/WindSock.java
+++ b/src/main/java/pwcg/mission/object/WindSock.java
@@ -45,16 +45,16 @@ public class WindSock
 
     public static WindSock createWindSock(Flight flight) throws PWCGException 
     {
-        double airfieldOrientation = flight.getAirfield().getPlaneOrientation();
+        double takeoffOrientation = flight.getAirfield().getTakeoffLocation().getOrientation().getyOri();
 
-        Double angleWindSockLeft = MathUtils.adjustAngle(airfieldOrientation, -90);
+        Double angleWindSockLeft = MathUtils.adjustAngle(takeoffOrientation, -90);
         
         Campaign campaign = PWCGContextManager.getInstance().getCampaign();
         ConfigManager configManager = campaign.getCampaignConfigManager();
         int windsockDistance = configManager.getIntConfigParam(ConfigItemKeys.WindsockDistanceKey);
-        Coordinate windSockCoordMoveLeft = MathUtils.calcNextCoord(flight.getAirfield().getPlanePosition().getPosition(), angleWindSockLeft, windsockDistance);
+        Coordinate windSockCoordMoveLeft = MathUtils.calcNextCoord(flight.getAirfield().getTakeoffLocation().getPosition(), angleWindSockLeft, windsockDistance);
 
-        double angleBack = MathUtils.adjustAngle(airfieldOrientation, 180);
+        double angleBack = MathUtils.adjustAngle(takeoffOrientation, 180);
         Coordinate windsockPos = MathUtils.calcNextCoord(windSockCoordMoveLeft, angleBack, 20.0);
 
         return new WindSock(windsockPos);

--- a/src/main/java/pwcg/mission/options/MapWeather.java
+++ b/src/main/java/pwcg/mission/options/MapWeather.java
@@ -24,6 +24,7 @@ public abstract class MapWeather
 	protected int tempPressLevel = 0;
 	protected int temperature = 15;
 	protected int pressure = 760;
+	protected int windDirection = 0;
 	
 	protected Flight playerFlight = null;
 	
@@ -33,6 +34,20 @@ public abstract class MapWeather
     {
     }
     	
+    public void createWindDirection()
+    {
+		// Prevailing direction is west to east
+		int eastOrWest = RandomNumberGenerator.getRandom(100);
+		if (eastOrWest > 80)
+		{
+			windDirection = 180 + RandomNumberGenerator.getRandom(180);
+		}
+		else
+		{
+			windDirection = RandomNumberGenerator.getRandom(180);
+		}
+    }
+
 	public void createMissionWeather(Flight playerFlight) throws PWCGException 
 	{		
 	    this.playerFlight = playerFlight;
@@ -344,42 +359,30 @@ public abstract class MapWeather
 		}
 		
 
-		// Prevailing direction is west to east
-		int direction = 0;
-		int eastOrWest = RandomNumberGenerator.getRandom(100);
-		if (eastOrWest > 80)
-		{
-			direction = 180 + RandomNumberGenerator.getRandom(180);
-		}
-		else
-		{
-			direction = RandomNumberGenerator.getRandom(180);
-		}
-		
 		WindLayer windLayer0 = new WindLayer();
 		windLayer0.layer = 0;
-		windLayer0.direction = direction;
+		windLayer0.direction = windDirection;
 		windLayer0.speed = 0 + RandomNumberGenerator.getRandom(3) / weatherDivisor;
 		
 		WindLayer windLayer500 = new WindLayer();
 		windLayer500.layer = 500;
-		windLayer500.direction = direction;
+		windLayer500.direction = windDirection;
 		windLayer500.speed = 1 + turbulenceFactor + RandomNumberGenerator.getRandom(3 + windSpeedModifier) / weatherDivisor;
 		
 		WindLayer windLayer1000 = new WindLayer();
 		windLayer1000.layer = 1000;
-		windLayer1000.direction = direction;
+		windLayer1000.direction = windDirection;
 		windLayer1000.speed = 1 + turbulenceFactor + RandomNumberGenerator.getRandom(4 + windSpeedModifier) / weatherDivisor;
 		
 		WindLayer windLayer3000 = new WindLayer();
 		windLayer3000.layer = 3000;
-		windLayer3000.direction = direction;
+		windLayer3000.direction = windDirection;
 		windLayer3000.speed = 1 + turbulenceFactor +  RandomNumberGenerator.getRandom(5 + windSpeedModifier) / weatherDivisor;
 
 		
 		WindLayer windLayer5000 = new WindLayer();
 		windLayer5000.layer = 5000;
-		windLayer5000.direction = direction;
+		windLayer5000.direction = windDirection;
 		windLayer5000.speed = 1 + turbulenceFactor + RandomNumberGenerator.getRandom(5 + windSpeedModifier) / weatherDivisor;	
 		
 		windLayers.clear();
@@ -446,6 +449,10 @@ public abstract class MapWeather
 
 	public int getPressure() {
 		return pressure;
+	}
+
+	public int getWindDirection() {
+		return windDirection;
 	}
 
     public class WindLayer

--- a/src/main/java/pwcg/mission/options/MapWeather.java
+++ b/src/main/java/pwcg/mission/options/MapWeather.java
@@ -455,6 +455,10 @@ public abstract class MapWeather
 		return windDirection;
 	}
 
+	public void setWindDirection(int windDirection) {
+		this.windDirection = windDirection;
+	}
+
     public class WindLayer
     {
         public int layer;

--- a/src/test/java/pwcg/campaign/group/AirfieldManagerTest.java
+++ b/src/test/java/pwcg/campaign/group/AirfieldManagerTest.java
@@ -25,7 +25,8 @@ public class AirfieldManagerTest
         AirfieldManager airfieldManager = PWCGContextManager.getInstance().getMapByMapId(FrontMapIdentifier.FRANCE_MAP).getAirfieldManager();
         for (IAirfield airfield : airfieldManager.getAllAirfields().values())
         {
-        	assert (airfield.getPlanePosition() != null);
+            assert (airfield.getTakeoffLocation() != null);
+            assert (airfield.getLandingLocation() != null);
         }
 	}
 

--- a/src/test/java/pwcg/campaign/ww2/airfield/BoSAirfieldTest.java
+++ b/src/test/java/pwcg/campaign/ww2/airfield/BoSAirfieldTest.java
@@ -3,6 +3,7 @@ package pwcg.campaign.ww2.airfield;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import pwcg.campaign.context.PWCGContextManager;
@@ -136,6 +137,25 @@ public class BoSAirfieldTest
 	{
         BoSAirfield airfield = (BoSAirfield) PWCGContextManager.getInstance().getAirfieldAllMaps(airfieldName);
 
+		PWCGContextManager.getInstance().getCurrentMap().getMapWeather().setWindDirection(180);
         assert(airfield.getChart().equals(refChart));
+	}
+
+	@Test
+	public void windTest() throws PWCGException
+	{
+		BoSAirfield airfield = (BoSAirfield) PWCGContextManager.getInstance().getAirfieldAllMaps("Rogachevko");
+
+		PWCGContextManager.getInstance().getCurrentMap().getMapWeather().setWindDirection(0);
+		assert((int) airfield.getTakeoffLocation().getOrientation().getyOri() == 225);
+
+		PWCGContextManager.getInstance().getCurrentMap().getMapWeather().setWindDirection(90);
+		assert((int) airfield.getTakeoffLocation().getOrientation().getyOri() == 278);
+
+		PWCGContextManager.getInstance().getCurrentMap().getMapWeather().setWindDirection(180);
+		assert((int) airfield.getTakeoffLocation().getOrientation().getyOri() == 45);
+
+		PWCGContextManager.getInstance().getCurrentMap().getMapWeather().setWindDirection(270);
+		assert((int) airfield.getTakeoffLocation().getOrientation().getyOri() == 98);
 	}
 }


### PR DESCRIPTION
Further updates to the runway code comprising:

- Some refactoring of the current IAirfield interface, removing some assumptions that the airfield location and the start of the runway are in the same place
- Fix the positioning of landing MCUs in BoX
- Making the empty space finder avoid placing hotspots on the taxiways, parking locations or secondary runways
- Dynamically choosing which runway to use (and in which direction) based on wind direction

Note that these changes shouldn't affect RoF, but I've not been able to do any testing to check this.