### PR TITLE
Fix "Object Unidentified" errors

### DIFF
--- a/src/main/java/pwcg/mission/briefing/PlayerFlightEditor.java
+++ b/src/main/java/pwcg/mission/briefing/PlayerFlightEditor.java
@@ -74,7 +74,7 @@ public class PlayerFlightEditor
 
         plane.setNumberInFormation(numInFormation);
         plane.setCallsign(playerFlight.getSquadron().determineCurrentCallsign(campaign.getDate()));
-        plane.setCallnum(numInFormation);
+        plane.setCallnum(numInFormation + 1);
         setPayloadFromBriefing(plane, crewPlane);
         setModificationsFromBriefing(plane, crewPlane);
         configurePlaneForCrew(plane, crewPlane);


### PR DESCRIPTION
TrainCoalCars were not being initialized, causing an empty script string
to be written to the Carriages section of the train.