### PR TITLE
Fixes for escort flights

### DIFF
--- a/src/main/java/pwcg/mission/flight/FlightFinalizer.java
+++ b/src/main/java/pwcg/mission/flight/FlightFinalizer.java
@@ -130,9 +130,11 @@ public class FlightFinalizer
     {
         // The mission begin timer triggers the formation timer.
         // For airstart, link the formation timer to the WP timer
-    	if (flight.getFlightInformation().isEscortedByPlayerFlight())
+        if (flight.getFlightInformation().isEscortedByPlayerFlight() ||
+            flight.getFlightInformation().isEscortForPlayerFlight())
         {
-            // Flights escorted by the player circle until rendezvous
+            // Flights escorted by the player or escorting the player
+            // circle until rendezvous
         }
     	else
     	{

--- a/src/main/java/pwcg/mission/flight/escort/EscortForPlayerFlight.java
+++ b/src/main/java/pwcg/mission/flight/escort/EscortForPlayerFlight.java
@@ -19,7 +19,7 @@ import pwcg.mission.flight.waypoint.WaypointFactory;
 import pwcg.mission.flight.waypoint.WaypointGeneratorBase;
 import pwcg.mission.flight.waypoint.WaypointType;
 import pwcg.mission.mcu.McuCover;
-import pwcg.mission.mcu.McuDeactivate;
+import pwcg.mission.mcu.McuForceComplete;
 import pwcg.mission.mcu.McuTimer;
 import pwcg.mission.mcu.McuWaypoint;
 
@@ -35,8 +35,8 @@ public class EscortForPlayerFlight extends Flight
     protected McuCover cover = null;
     protected McuTimer coverTimer  = null;
 
-    protected McuTimer deactivateCoverTimer = null;
-    protected McuDeactivate deactivateCoverEntity = null;
+    protected McuTimer forceCompleteTimer = null;
+    protected McuForceComplete forceCompleteEntity = null;
 
     protected Coordinate rendevousCoord;
     
@@ -61,7 +61,7 @@ public class EscortForPlayerFlight extends Flight
         createFormation();
         setFlightPayload();
         createCover();
-        createDeactivate();
+        createForceComplete();
     }
 
     @Override
@@ -87,9 +87,9 @@ public class EscortForPlayerFlight extends Flight
         McuWaypoint egressWP = WaypointGeneratorBase.findWaypointByType(getPlayerFlight().getAllWaypoints(), 
                         WaypointType.EGRESS_WAYPOINT.getName());
 
-        egressWP.setTarget(getDeactivateCoverTimer().getIndex());
+        egressWP.setTarget(getForceCompleteTimer().getIndex());
 
-        getDeactivateCoverTimer().setTarget(getWaypointPackage().getWaypointsForLeadPlane().get(0).getIndex());
+        getForceCompleteTimer().setTarget(getWaypointPackage().getWaypointsForLeadPlane().get(0).getIndex());
     }
 
     public void createCover() throws PWCGException 
@@ -115,23 +115,23 @@ public class EscortForPlayerFlight extends Flight
         
     }
 
-    protected void createDeactivate() 
+    protected void createForceComplete()
     {
         // Deactivate the cover entity
-        deactivateCoverEntity = new McuDeactivate();
-        deactivateCoverEntity.setName("Escort Cover Deactivate Cover");
-        deactivateCoverEntity.setDesc("Escort Cover Deactivate Cover");
-        deactivateCoverEntity.setOrientation(new Orientation());
-        deactivateCoverEntity.setPosition(flightInformation.getTargetCoords().copy());                
-        deactivateCoverEntity.setTarget(cover.getIndex());
+        forceCompleteEntity = new McuForceComplete();
+        forceCompleteEntity.setName("Escort Cover Force Complete");
+        forceCompleteEntity.setDesc("Escort Cover Force Complete");
+        forceCompleteEntity.setOrientation(new Orientation());
+        forceCompleteEntity.setPosition(flightInformation.getTargetCoords().copy());
+        forceCompleteEntity.setObject(planes.get(0).getEntity().getIndex());
         
-        deactivateCoverTimer  = new McuTimer();
-        deactivateCoverTimer.setName("Escort Cover Deactivate Cover Timer");
-        deactivateCoverTimer.setDesc("Escort Cover Deactivate Cover Timer");
-        deactivateCoverTimer.setOrientation(new Orientation());
-        deactivateCoverTimer.setPosition(flightInformation.getTargetCoords().copy());             
-        deactivateCoverTimer.setTimer(2);               
-        deactivateCoverTimer.setTarget(deactivateCoverEntity.getIndex());
+        forceCompleteTimer  = new McuTimer();
+        forceCompleteTimer.setName("Escort Cover Force Complete Timer");
+        forceCompleteTimer.setDesc("Escort Cover Force Complete Timer");
+        forceCompleteTimer.setOrientation(new Orientation());
+        forceCompleteTimer.setPosition(flightInformation.getTargetCoords().copy());
+        forceCompleteTimer.setTimer(2);
+        forceCompleteTimer.setTarget(forceCompleteEntity.getIndex());
     }
 
     protected void createPlaneInitialPosition() throws PWCGException 
@@ -227,8 +227,8 @@ public class EscortForPlayerFlight extends Flight
         coverTimer.write(writer);
         cover.write(writer);
         
-        deactivateCoverTimer.write(writer);
-        deactivateCoverEntity.write(writer);
+        forceCompleteTimer.write(writer);
+        forceCompleteEntity.write(writer);
     }
 
 
@@ -256,27 +256,27 @@ public class EscortForPlayerFlight extends Flight
     }
 
 
-    public McuTimer getDeactivateCoverTimer()
+    public McuTimer getForceCompleteTimer()
     {
-        return deactivateCoverTimer;
+        return forceCompleteTimer;
     }
 
 
-    public void setDeactivateCoverTimer(McuTimer deactivateCoverTimer)
+    public void setForceCompleteTimer(McuTimer forceCompleteTimer)
     {
-        this.deactivateCoverTimer = deactivateCoverTimer;
+        this.forceCompleteTimer = forceCompleteTimer;
     }
 
 
-    public McuDeactivate getDeactivateCoverEntity()
+    public McuForceComplete getForceCompleteEntity()
     {
-        return deactivateCoverEntity;
+        return forceCompleteEntity;
     }
 
 
-    public void setDeactivateCoverEntity(McuDeactivate deactivateCoverEntity)
+    public void setForceCompleteEntity(McuForceComplete forceCompleteEntity)
     {
-        this.deactivateCoverEntity = deactivateCoverEntity;
+        this.forceCompleteEntity = forceCompleteEntity;
     }
 
 

--- a/src/main/java/pwcg/mission/flight/escort/PlayerEscortFlight.java
+++ b/src/main/java/pwcg/mission/flight/escort/PlayerEscortFlight.java
@@ -18,7 +18,7 @@ import pwcg.mission.flight.FlightPositionHelperPlayerStart;
 import pwcg.mission.flight.waypoint.WaypointGeneratorBase;
 import pwcg.mission.flight.waypoint.WaypointType;
 import pwcg.mission.mcu.McuCover;
-import pwcg.mission.mcu.McuDeactivate;
+import pwcg.mission.mcu.McuForceComplete;
 import pwcg.mission.mcu.McuTimer;
 import pwcg.mission.mcu.McuWaypoint;
 
@@ -34,8 +34,8 @@ public class PlayerEscortFlight extends Flight
 	protected McuCover cover = null;
 	protected McuTimer coverTimer  = null;
 
-	protected McuTimer deactivateCoverTimer = null;
-	protected McuDeactivate deactivateCoverEntity = null;
+	protected McuTimer forceCompleteTimer = null;
+	protected McuForceComplete forceCompleteEntity = null;
 
     protected McuTimer escortedFlightWaypointTimer = null;
     protected McuTimer egressTimer = null;
@@ -64,7 +64,7 @@ public class PlayerEscortFlight extends Flight
 	{
 		createTimers();
 		createCover();
-		createDeactivate();
+		createForceComplete();
 		createActivation();
 
         FlightPositionHelperPlayerStart flightPositionHelperPlayerStart = new FlightPositionHelperPlayerStart(getCampaign(), this);
@@ -143,9 +143,9 @@ public class PlayerEscortFlight extends Flight
 	{
 		List<McuWaypoint> escortedWaypoints = getEscortedFlight().getAllWaypoints();
 		McuWaypoint escortedEgress = WaypointGeneratorBase.findWaypointByType(escortedWaypoints, WaypointType.EGRESS_WAYPOINT.getName());
-		escortedEgress.setTarget(deactivateCoverTimer.getIndex());
+		escortedEgress.setTarget(forceCompleteTimer.getIndex());
 
-		deactivateCoverTimer.setTarget(egressTimer.getIndex());
+		forceCompleteTimer.setTarget(egressTimer.getIndex());
 		egressTimer.setTarget(nextWP.getIndex());
 	}
 
@@ -189,23 +189,23 @@ public class PlayerEscortFlight extends Flight
 		coverTimer.setTarget(cover.getIndex());
 	}
 
-	protected void createDeactivate() throws PWCGException 
+	protected void createForceComplete() throws PWCGException
 	{
 		// Deactivate the cover entity
-		deactivateCoverEntity = new McuDeactivate();
-		deactivateCoverEntity.setName("Escort Cover Deactivate Cover");
-		deactivateCoverEntity.setDesc("Escort Cover Deactivate Cover");
-		deactivateCoverEntity.setOrientation(new Orientation());
-		deactivateCoverEntity.setPosition(getTargetCoords().copy());				
-		deactivateCoverEntity.setTarget(cover.getIndex());
+		forceCompleteEntity = new McuForceComplete();
+		forceCompleteEntity.setName("Escort Cover Force Complete");
+		forceCompleteEntity.setDesc("Escort Cover Force Complete");
+		forceCompleteEntity.setOrientation(new Orientation());
+		forceCompleteEntity.setPosition(getTargetCoords().copy());
+		forceCompleteEntity.setObject(planes.get(0).getEntity().getIndex());
 		
-		deactivateCoverTimer  = new McuTimer();
-		deactivateCoverTimer.setName("Escort Cover Deactivate Cover Timer");
-		deactivateCoverTimer.setDesc("Escort Cover Deactivate Cover Timer");
-		deactivateCoverTimer.setOrientation(new Orientation());
-		deactivateCoverTimer.setPosition(getTargetCoords().copy());				
-		deactivateCoverTimer.setTimer(2);				
-		deactivateCoverTimer.setTarget(deactivateCoverEntity.getIndex());
+		forceCompleteTimer  = new McuTimer();
+		forceCompleteTimer.setName("Escort Cover Force Complete Timer");
+		forceCompleteTimer.setDesc("Escort Cover Force Complete Timer");
+		forceCompleteTimer.setOrientation(new Orientation());
+		forceCompleteTimer.setPosition(getTargetCoords().copy());
+		forceCompleteTimer.setTimer(2);
+		forceCompleteTimer.setTarget(forceCompleteEntity.getIndex());
 	}
 
     protected void createTimers() throws PWCGException 
@@ -256,8 +256,8 @@ public class PlayerEscortFlight extends Flight
 		cover.write(writer);
 		escortedFlightWaypointTimer.write(writer);
 		
-		deactivateCoverTimer.write(writer);
-		deactivateCoverEntity.write(writer);
+		forceCompleteTimer.write(writer);
+		forceCompleteEntity.write(writer);
 		egressTimer.write(writer);
 	}
 
@@ -289,14 +289,14 @@ public class PlayerEscortFlight extends Flight
 		return coverTimer;
 	}
 
-	public McuTimer getDeactivateCoverTimer() 
+	public McuTimer getForceCompleteTimer()
 	{
-		return deactivateCoverTimer;
+		return forceCompleteTimer;
 	}
 
-	public McuDeactivate getDeactivateCoverEntity() 
+	public McuForceComplete getForceCompleteEntity()
 	{
-		return deactivateCoverEntity;
+		return forceCompleteEntity;
 	}
 
 	public McuTimer getEscortedFlightWaypointTimer() 

--- a/src/test/java/pwcg/mission/flight/validate/PlayerEscortFlightValidator.java
+++ b/src/test/java/pwcg/mission/flight/validate/PlayerEscortFlightValidator.java
@@ -14,6 +14,7 @@ import pwcg.mission.flight.waypoint.WaypointAction;
 import pwcg.mission.flight.waypoint.WaypointPriority;
 import pwcg.mission.mcu.McuCover;
 import pwcg.mission.mcu.McuDeactivate;
+import pwcg.mission.mcu.McuForceComplete;
 import pwcg.mission.mcu.McuTimer;
 import pwcg.mission.mcu.McuWaypoint;
 
@@ -66,8 +67,8 @@ public class PlayerEscortFlightValidator
 		McuCover cover = playerFlight.getCover();
 	    McuTimer escortedFlightWaypointTimer = playerFlight.getEscortedFlightWaypointTimer();
 
-		McuTimer deactivateCoverTimer = playerFlight.getDeactivateCoverTimer();
-		McuDeactivate deactivateCoverEntity = playerFlight.getDeactivateCoverEntity();
+		McuTimer forceCompleteTimer = playerFlight.getForceCompleteTimer();
+		McuForceComplete forceCompleteEntity = playerFlight.getForceCompleteEntity();
 	    McuTimer egressTimer = playerFlight.getEgressTimer();
 
 		McuWaypoint prevWaypoint = null;
@@ -98,9 +99,9 @@ public class PlayerEscortFlightValidator
 				else if (prevWaypoint.getWpAction().equals(WaypointAction.WP_ACTION_EGRESS))
 				{
 					assert(isNextWaypointLinked);
-					assert(isIndexInTargetList(deactivateCoverTimer.getIndex(), escortedEgressWP.getTargets()));
-					assert(isIndexInTargetList(deactivateCoverEntity.getIndex(), deactivateCoverTimer.getTargets()));
-					assert(isIndexInTargetList(egressTimer.getIndex(), deactivateCoverTimer.getTargets()));
+					assert(isIndexInTargetList(forceCompleteTimer.getIndex(), escortedEgressWP.getTargets()));
+					assert(isIndexInTargetList(forceCompleteEntity.getIndex(), forceCompleteTimer.getTargets()));
+					assert(isIndexInTargetList(egressTimer.getIndex(), forceCompleteTimer.getTargets()));
 					assert(isIndexInTargetList(prevWaypoint.getIndex(), egressTimer.getTargets()));
 				}
 				else


### PR DESCRIPTION
 - AI escorts for the player would not wait at the rendezvous point, but
   would instead fly to their home airfield and circle there until the
   player reached the rendezvous, then would try to catch up with the
   player
 - Once the egress point is reached, AI escort flights (or the player
   escort flight if the player was not flight leader) would not stop
   escorting, so would follow the escorted flight back to the home
   airfield and then circle. It's necessary to use force complete on the
   flight leader to end a cover command, deactivating the cover iteslf
   doesn't seem to work.