### PR TITLE
Get rank abbreviations for RAF/USAAF

### DIFF
--- a/src/main/java/pwcg/campaign/ww2/country/BoSRank.java
+++ b/src/main/java/pwcg/campaign/ww2/country/BoSRank.java
@@ -136,6 +136,18 @@ public class BoSRank implements IRankHelper
             return abbrev;
         }
 
+        abbrev = getRankAbbrevByService (rank, usaaf);
+        if (abbrev.length() > 0)
+        {
+            return abbrev;
+        }
+
+        abbrev = getRankAbbrevByService (rank, raf);
+        if (abbrev.length() > 0)
+        {
+            return abbrev;
+        }
+
         return "";
     }
 


### PR DESCRIPTION
Abbreviated ranks are currently missing for RAF/USAAF personnel