### PR TITLE
Tactical codes

### DIFF
--- a/BoSData/Input/Aircraft/p51d15.json
+++ b/BoSData/Input/Aircraft/p51d15.json
@@ -11,6 +11,7 @@
 		"MN28",
 		"OCTANE_150_FUEL"
 	],
+	"tacticalCodeColor": "BLACK",
 	"displayName": "P-51D-15",
 	"script": "LuaScripts\\WorldObjects\\Planes\\p51d15.txt",
 	"model": "graphics\\planes\\p51d15\\p51d15.mgm",

--- a/BoSData/Input/Skins/Configured/p51d15.json
+++ b/BoSData/Input/Skins/Configured/p51d15.json
@@ -1,8 +1,8 @@
 {
 	"skinSetType": "SKIN_CONFIGURED",
 	"skins": {
-		"p51d15_skin_00": {
-			"skinName": "p51d15_skin_00",
+		"p51d15na_skin_00": {
+			"skinName": "p51d15na_skin_00",
 			"planeType": "p51d15",
 			"startDate": "19400801",
 			"endDate": "19450601",
@@ -10,10 +10,25 @@
 			"country": "USA",
 			"category": "Configured",
 			"definedInGame": true,
-			"winter": false
+			"winter": false,
+			"useTacticalCodes": true,
+			"tacticalCodeColor": "BLACK"
 		},
-		"p51d15_skin_01": {
-			"skinName": "p51d15_skin_01",
+		"p51d15na_skin_01": {
+			"skinName": "p51d15na_skin_01",
+			"planeType": "p51d15",
+			"startDate": "19400801",
+			"endDate": "19450601",
+			"squadId": -1,
+			"country": "USA",
+			"category": "Configured",
+			"definedInGame": true,
+			"winter": false,
+			"useTacticalCodes": true,
+			"tacticalCodeColor": "SKY"
+		},
+		"p51d15na_skin_02": {
+			"skinName": "p51d15na_skin_02",
 			"planeType": "p51d15",
 			"startDate": "19400801",
 			"endDate": "19450601",
@@ -23,8 +38,8 @@
 			"definedInGame": true,
 			"winter": false
 		},
-		"p51d15_skin_02": {
-			"skinName": "p51d15_skin_02",
+		"p51d15na_skin_03": {
+			"skinName": "p51d15na_skin_03",
 			"planeType": "p51d15",
 			"startDate": "19400801",
 			"endDate": "19450601",
@@ -34,8 +49,8 @@
 			"definedInGame": true,
 			"winter": false
 		},
-		"p51d15_skin_03": {
-			"skinName": "p51d15_skin_03",
+		"p51d15na_skin_04": {
+			"skinName": "p51d15na_skin_04",
 			"planeType": "p51d15",
 			"startDate": "19400801",
 			"endDate": "19450601",
@@ -45,8 +60,8 @@
 			"definedInGame": true,
 			"winter": false
 		},
-		"p51d15_skin_04": {
-			"skinName": "p51d15_skin_04",
+		"p51d15na_skin_05": {
+			"skinName": "p51d15na_skin_05",
 			"planeType": "p51d15",
 			"startDate": "19400801",
 			"endDate": "19450601",
@@ -56,19 +71,8 @@
 			"definedInGame": true,
 			"winter": false
 		},
-		"p51d15_skin_05": {
-			"skinName": "p51d15_skin_05",
-			"planeType": "p51d15",
-			"startDate": "19400801",
-			"endDate": "19450601",
-			"squadId": -1,
-			"country": "USA",
-			"category": "Configured",
-			"definedInGame": true,
-			"winter": false
-		},
-		"p51d15_skin_06": {
-			"skinName": "p51d15_skin_06",
+		"p51d15na_skin_06": {
+			"skinName": "p51d15na_skin_06",
 			"planeType": "p51d15",
 			"startDate": "19400801",
 			"endDate": "19450601",
@@ -78,8 +82,8 @@
 			"definedInGame": true,
 			"winter": false
 		},
-		"p51d15_skin_08": {
-			"skinName": "p51d15_skin_08",
+		"p51d15na_skin_08": {
+			"skinName": "p51d15na_skin_08",
 			"planeType": "p51d15",
 			"startDate": "19400801",
 			"endDate": "19450601",
@@ -89,8 +93,8 @@
 			"definedInGame": true,
 			"winter": false
 		},
-		"p51d15_skin_09": {
-			"skinName": "p51d15_skin_09",
+		"p51d15na_skin_09": {
+			"skinName": "p51d15na_skin_09",
 			"planeType": "p51d15",
 			"startDate": "19400801",
 			"endDate": "19450601",
@@ -100,8 +104,8 @@
 			"definedInGame": true,
 			"winter": false
 		},
-		"p51d15_skin_10": {
-			"skinName": "p51d15_skin_10",
+		"p51d15na_skin_10": {
+			"skinName": "p51d15na_skin_10",
 			"planeType": "p51d15",
 			"startDate": "19400801",
 			"endDate": "19450601",
@@ -111,8 +115,8 @@
 			"definedInGame": true,
 			"winter": false
 		},
-		"p51d15_skin_13": {
-			"skinName": "p51d15_skin_13",
+		"p51d15na_skin_13": {
+			"skinName": "p51d15na_skin_13",
 			"planeType": "p51d15",
 			"startDate": "19400801",
 			"endDate": "19450601",

--- a/BoSData/Input/Squadron/139 Squadron.json
+++ b/BoSData/Input/Squadron/139 Squadron.json
@@ -4,6 +4,7 @@
   "name": "139 Squadron",
   "fileName": "139 Squadron.json",
   "skill": 70,
+  "unitIdCode": "XD",
   "planeAssignments": [
     {
       "archType": "b25",

--- a/BoSData/Input/Squadron/182 Squadron.json
+++ b/BoSData/Input/Squadron/182 Squadron.json
@@ -4,6 +4,7 @@
   "name": "182 Squadron",
   "fileName": "182 Squadron.json",
   "skill": 65,
+  "unitIdCode": "XM",
   "planeAssignments": [
     {
       "archType": "tempest",

--- a/BoSData/Input/Squadron/184 Squadron.json
+++ b/BoSData/Input/Squadron/184 Squadron.json
@@ -4,6 +4,7 @@
   "name": "184 Squadron",
   "fileName": "184 Squadron.json",
   "skill": 70,
+  "unitIdCode": "BR",
   "planeAssignments": [
     {
       "archType": "tempest",

--- a/BoSData/Input/Squadron/193 Squadron.json
+++ b/BoSData/Input/Squadron/193 Squadron.json
@@ -4,6 +4,7 @@
   "name": "193 Squadron",
   "fileName": "193 Squadron.json",
   "skill": 70,
+  "unitIdCode": "DP",
   "planeAssignments": [
     {
       "archType": "spitfire",

--- a/BoSData/Input/Squadron/21 Gruppo Caccia.json
+++ b/BoSData/Input/Squadron/21 Gruppo Caccia.json
@@ -4,6 +4,7 @@
 	"name": "22 Gruppo Caccia",
 	"fileName": "21 Gruppo Caccia.json",
 	"skill": 55,
+	"unitIdCode": "356",
 	"planeAssignments": [
 		{
 			"archType": "mc200",

--- a/BoSData/Input/Squadron/326 Squadron.json
+++ b/BoSData/Input/Squadron/326 Squadron.json
@@ -4,6 +4,7 @@
   "name": "326 Squadron",
   "fileName": "326 Squadron.json",
   "skill": 65,
+  "unitIdCode": "QU",
   "planeAssignments": [
     {
       "archType": "spitfire",

--- a/BoSData/Input/Squadron/349 Squadron.json
+++ b/BoSData/Input/Squadron/349 Squadron.json
@@ -4,6 +4,7 @@
   "name": "349 Squadron",
   "fileName": "349 Squadron.json",
   "skill": 70,
+  "unitIdCode": "GE",
   "planeAssignments": [
     {
       "archType": "spitfire",

--- a/BoSData/Input/Squadron/352nd FG.json
+++ b/BoSData/Input/Squadron/352nd FG.json
@@ -4,6 +4,7 @@
   "name": "352nd Fighter Group",
   "fileName": "352nd FG.json",
   "skill": 80,
+  "unitIdCode": "PZ",
   "planeAssignments": [
     {
       "archType": "p51",

--- a/BoSData/Input/Squadron/354th FG.json
+++ b/BoSData/Input/Squadron/354th FG.json
@@ -4,6 +4,7 @@
   "name": "354th Fighter Group",
   "fileName": "354th FG.json",
   "skill": 80,
+  "unitIdCode": "AJ",
   "planeAssignments": [
     {
       "archType": "p51",

--- a/BoSData/Input/Squadron/358th FG.json
+++ b/BoSData/Input/Squadron/358th FG.json
@@ -4,6 +4,7 @@
   "name": "358th Fighter Group",
   "fileName": "358th FG.json",
   "skill": 80,
+  "unitIdCode": "CH",
   "planeAssignments": [
     {
       "archType": "p47",

--- a/BoSData/Input/Squadron/365th FG.json
+++ b/BoSData/Input/Squadron/365th FG.json
@@ -4,6 +4,7 @@
   "name": "365th Fighter Group",
   "fileName": "365th FG.json",
   "skill": 70,
+  "unitIdCode": "D5",
   "planeAssignments": [
     {
       "archType": "p47",

--- a/BoSData/Input/Squadron/366th FG.json
+++ b/BoSData/Input/Squadron/366th FG.json
@@ -4,6 +4,7 @@
   "name": "366th Fighter Group",
   "fileName": "366th FG.json",
   "skill": 80,
+  "unitIdCode": "A6",
   "planeAssignments": [
     {
       "archType": "p47",

--- a/BoSData/Input/Squadron/36th FG.json
+++ b/BoSData/Input/Squadron/36th FG.json
@@ -4,6 +4,7 @@
   "name": "36th Fighter Group",
   "fileName": "36th FG.json",
   "skill": 65,
+  "unitIdCode": "3T",
   "planeAssignments": [
     {
       "archType": "p47",

--- a/BoSData/Input/Squadron/373rd FG.json
+++ b/BoSData/Input/Squadron/373rd FG.json
@@ -4,6 +4,7 @@
   "name": "373rd Fighter Group",
   "fileName": "373rd FG.json",
   "skill": 65,
+  "unitIdCode": "R3",
   "planeAssignments": [
     {
       "archType": "p47",

--- a/BoSData/Input/Squadron/387th BG.json
+++ b/BoSData/Input/Squadron/387th BG.json
@@ -4,6 +4,7 @@
   "name": "387th Bomber Group",
   "fileName": "387th BG.json",
   "skill": 70,
+  "unitIdCode": "TQ",
   "planeAssignments": [
     {
       "archType": "a20",

--- a/BoSData/Input/Squadron/403 Squadron.json
+++ b/BoSData/Input/Squadron/403 Squadron.json
@@ -4,6 +4,7 @@
   "name": "403 Squadron",
   "fileName": "403 Squadron.json",
   "skill": 75,
+  "unitIdCode": "KH",
   "planeAssignments": [
     {
       "archType": "spitfire",

--- a/BoSData/Input/Squadron/410th BG.json
+++ b/BoSData/Input/Squadron/410th BG.json
@@ -4,6 +4,7 @@
   "name": "410th Bomber Group",
   "fileName": "410th BG.json",
   "skill": 70,
+  "unitIdCode": "8U",
   "planeAssignments": [
     {
       "archType": "a20",

--- a/BoSData/Input/Squadron/437th TG.json
+++ b/BoSData/Input/Squadron/437th TG.json
@@ -4,6 +4,7 @@
   "name": "437th Transport Group",
   "fileName": "437th TG.json",
   "skill": 30,
+  "unitIdCode": "T2",
   "planeAssignments": [
     {
       "archType": "c47",

--- a/BoSData/Input/Squadron/474th FG.json
+++ b/BoSData/Input/Squadron/474th FG.json
@@ -4,6 +4,7 @@
   "name": "474th Fighter Group",
   "fileName": "474th FG.json",
   "skill": 70,
+  "unitIdCode": "7Y",
   "planeAssignments": [
     {
       "archType": "p38",

--- a/BoSData/Input/Squadron/48th FG.json
+++ b/BoSData/Input/Squadron/48th FG.json
@@ -4,6 +4,7 @@
   "name": "48th Fighter Group",
   "fileName": "48th FG.json",
   "skill": 65,
+  "unitIdCode": "F4",
   "planeAssignments": [
     {
       "archType": "p47",

--- a/BoSData/Input/Squadron/4_PzSch_G_2.json
+++ b/BoSData/Input/Squadron/4_PzSch_G_2.json
@@ -4,6 +4,7 @@
   "name": "4.(Pz)/Sch.G.2",
   "fileName": "4_PzSch_G_2.json",
   "skill": 70,
+  "subUnitIdCode": "\u25b2",
   "planeAssignments": [
     {
       "archType": "hs129",
@@ -44,13 +45,15 @@
         "date": "19431018",
         "squadName": "12.(Pz)/SG9",
         "armedServiceName": "Luftwaffe",
-        "skill": 70
+        "skill": 70,
+        "subUnitIdCode": ""
       },
       {
         "date": "19450107",
         "squadName": "1.(Pz)/SG9",
         "armedServiceName": "Luftwaffe",
-        "skill": 70
+        "skill": 70,
+        "subUnitIdCode": ""
       }
     ]
   },

--- a/BoSData/Input/Squadron/50th FG.json
+++ b/BoSData/Input/Squadron/50th FG.json
@@ -4,6 +4,7 @@
   "name": "50th Fighter Group",
   "fileName": "50th FG.json",
   "skill": 65,
+  "unitIdCode": "T5",
   "planeAssignments": [
     {
       "archType": "p47",

--- a/BoSData/Input/Squadron/56 Squadron.json
+++ b/BoSData/Input/Squadron/56 Squadron.json
@@ -4,6 +4,7 @@
   "name": "56 Squadron",
   "fileName": "56 Squadron.json",
   "skill": 65,
+  "unitIdCode": "US",
   "planeAssignments": [
     {
       "archType": "tempest",

--- a/BoSData/Input/Squadron/66 Squadron.json
+++ b/BoSData/Input/Squadron/66 Squadron.json
@@ -4,6 +4,7 @@
   "name": "66 Squadron",
   "fileName": "66 Squadron.json",
   "skill": 75,
+  "unitIdCode": "LZ",
   "planeAssignments": [
     {
       "archType": "spitfire",

--- a/BoSData/Input/Squadron/III_KG27.json
+++ b/BoSData/Input/Squadron/III_KG27.json
@@ -4,6 +4,8 @@
   "name": "III./KG27",
   "fileName": "III_KG27.json",
   "skill": 60,
+  "unitIdCode": "1G",
+  "subUnitIdCode": "S",
   "planeAssignments": [
     {
       "archType": "he111",
@@ -88,7 +90,9 @@
         "date": "19430918",
         "squadName": "III./KG55",
         "armedServiceName": "Luftwaffe",
-        "skill": 50
+        "skill": 50,
+        "unitIdCode": "G1",
+        "subUnitIdCode": "S"
       }
     ]
   },

--- a/BoSData/Input/Squadron/II_JG51.json
+++ b/BoSData/Input/Squadron/II_JG51.json
@@ -4,6 +4,7 @@
   "name": "II./JG51",
   "fileName": "II_JG51.json",
   "skill": 90,
+  "subUnitIdCode": "-",
   "planeAssignments": [
     {
       "archType": "bf109",

--- a/BoSData/Input/Squadron/II_JG52.json
+++ b/BoSData/Input/Squadron/II_JG52.json
@@ -4,6 +4,7 @@
   "name": "II./JG52",
   "fileName": "II_JG52.json",
   "skill": 90,
+  "subUnitIdCode": "-",
   "planeAssignments": [
     {
       "archType": "bf109",

--- a/BoSData/Input/Squadron/II_KG53.json
+++ b/BoSData/Input/Squadron/II_KG53.json
@@ -4,6 +4,8 @@
 	"name": "II./KG53",
 	"fileName": "II_KG53.json",
 	"skill": 50,
+	"unitIdCode": "A1",
+	"subUnitIdCode": "M",
 	"planeAssignments": [
 		{
 			"archType": "he111",
@@ -93,13 +95,17 @@
 				"date": "19420301",
 				"squadName": "II./KG27",
 				"armedServiceName": "Luftwaffe",
-				"skill": 50
+				"skill": 50,
+				"unitIdCode": "1G",
+				"subUnitIdCode": "M"
 			},
 			{
 				"date": "19430918",
 				"squadName": "II./KG4",
 				"armedServiceName": "Luftwaffe",
-				"skill": 40
+				"skill": 40,
+				"unitIdCode": "5J",
+				"subUnitIdCode": "M"
 			}
 		]
 	},

--- a/BoSData/Input/Squadron/II_KG76.json
+++ b/BoSData/Input/Squadron/II_KG76.json
@@ -4,6 +4,8 @@
   "name": "II./KG76",
   "fileName": "II_KG76.json",
   "skill": 55,
+  "unitIdCode": "F1",
+  "subUnitIdCode": "N",
   "planeAssignments": [
     {
       "archType": "ju88",
@@ -85,13 +87,17 @@
         "date": "19430918",
         "squadName": "II./KG51",
         "armedServiceName": "Luftwaffe",
-        "skill": 45
+        "skill": 45,
+        "unitIdCode": "9K",
+        "subUnitIdCode": "N"
       },
       {
         "date": "19440901",
         "squadName": "II./KG54",
         "armedServiceName": "Luftwaffe",
-        "skill": 45
+        "skill": 45,
+        "unitIdCode": "B3",
+        "subUnitIdCode": "N"
       }
     ]
   },

--- a/BoSData/Input/Squadron/II_SG4.json
+++ b/BoSData/Input/Squadron/II_SG4.json
@@ -4,6 +4,7 @@
   "name": "II./SG 4",
   "fileName": "II_SG4.json",
   "skill": 60,
+  "subUnitIdCode": "-",
   "planeAssignments": [
     {
       "archType": "fw190",

--- a/BoSData/Input/Squadron/II_Sch_G_1.json
+++ b/BoSData/Input/Squadron/II_Sch_G_1.json
@@ -4,6 +4,7 @@
   "name": "II./Sch.G.1",
   "fileName": "II_Sch_G_1.json",
   "skill": 60,
+  "subUnitIdCode": "\u25b2",
   "planeAssignments": [
     {
       "archType": "bf109e",
@@ -104,7 +105,8 @@
         "date": "19431018",
         "squadName": "I./SG4",
         "armedServiceName": "Luftwaffe",
-        "skill": 55
+        "skill": 55,
+        "subUnitIdCode": ""
       }
     ]
   },

--- a/BoSData/Input/Squadron/II_St_G_2.json
+++ b/BoSData/Input/Squadron/II_St_G_2.json
@@ -4,6 +4,8 @@
 	"name": "II./St.G.2",
 	"fileName": "II_St_G_2.json",
 	"skill": 60,
+	"unitIdCode": "T6",
+	"subUnitIdCode": "M",
 	"planeAssignments": [
 		{
 			"archType": "ju87",
@@ -72,7 +74,8 @@
 				"date": "19431018",
 				"squadName": "I./SG2",
 				"armedServiceName": "Luftwaffe",
-				"skill": 45
+				"skill": 45,
+				"subUnitIdCode": ""
 			}
 		]
 	},

--- a/BoSData/Input/Squadron/II_St_G_77.json
+++ b/BoSData/Input/Squadron/II_St_G_77.json
@@ -4,6 +4,8 @@
 	"name": "II./St.G.77",
 	"fileName": "II_St_G_77.json",
 	"skill": 60,
+	"unitIdCode": "S2",
+	"subUnitIdCode": "N",
 	"planeAssignments": [
 		{
 			"archType": "ju87",
@@ -97,7 +99,8 @@
 				"date": "19431018",
 				"squadName": "III./SG10",
 				"armedServiceName": "Luftwaffe",
-				"skill": 55
+				"skill": 55,
+				"subUnitIdCode": "|"
 			}
 		]
 	},

--- a/BoSData/Input/Squadron/II_TG1.json
+++ b/BoSData/Input/Squadron/II_TG1.json
@@ -4,6 +4,8 @@
   "name": "II./TG1",
   "fileName": "II_TG1.json",
   "skill": 50,
+  "unitIdCode": "1Z",
+  "subUnitIdCode": "P",
   "planeAssignments": [
     {
       "archType": "ju52",

--- a/BoSData/Input/Squadron/II_ZG26.json
+++ b/BoSData/Input/Squadron/II_ZG26.json
@@ -4,6 +4,8 @@
   "name": "II./ZG 26",
   "fileName": "II_ZG26.json",
   "skill": 70,
+  "unitIdCode": "3U",
+  "subUnitIdCode": "S",
   "planeAssignments": [
     {
       "archType": "bf110",

--- a/BoSData/Input/Squadron/I_JG1.json
+++ b/BoSData/Input/Squadron/I_JG1.json
@@ -4,6 +4,7 @@
   "name": "I./JG1",
   "fileName": "I_JG1.json",
   "skill": 85,
+  "subUnitIdCode": "",
   "planeAssignments": [
     {
       "archType": "fw190",

--- a/BoSData/Input/Squadron/I_JG2.json
+++ b/BoSData/Input/Squadron/I_JG2.json
@@ -4,6 +4,7 @@
   "name": "I./JG2",
   "fileName": "I_JG2.json",
   "skill": 90,
+  "subUnitIdCode": "",
   "planeAssignments": [
     {
       "archType": "fw190",
@@ -84,7 +85,8 @@
         "date": "19440901",
         "squadName": "I./JG2",
         "armedServiceName": "Luftwaffe",
-        "skill": 70
+        "skill": 70,
+        "subUnitIdCode": ""
       }
     ]
   },

--- a/BoSData/Input/Squadron/I_JG26.json
+++ b/BoSData/Input/Squadron/I_JG26.json
@@ -4,6 +4,7 @@
   "name": "I./JG26",
   "fileName": "I_JG26.json",
   "skill": 90,
+  "subUnitIdCode": "",
   "planeAssignments": [
     {
       "archType": "fw190",

--- a/BoSData/Input/Squadron/I_JG27.json
+++ b/BoSData/Input/Squadron/I_JG27.json
@@ -4,6 +4,7 @@
   "name": "I./JG27",
   "fileName": "I_JG27.json",
   "skill": 85,
+  "subUnitIdCode": "",
   "planeAssignments": [
     {
       "archType": "fw190",

--- a/BoSData/Input/Squadron/I_JG3.json
+++ b/BoSData/Input/Squadron/I_JG3.json
@@ -4,6 +4,7 @@
 	"name": "I./JG3",
 	"fileName": "I_JG3.json",
 	"skill": 85,
+	"subUnitIdCode": "",
 	"planeAssignments": [
 		{
 			"archType": "bf109",

--- a/BoSData/Input/Squadron/I_JG51.json
+++ b/BoSData/Input/Squadron/I_JG51.json
@@ -4,6 +4,7 @@
   "name": "I./JG51",
   "fileName": "I_JG51.json",
   "skill": 90,
+  "subUnitIdCode": "",
   "planeAssignments": [
     {
       "archType": "bf109",

--- a/BoSData/Input/Squadron/I_JG52.json
+++ b/BoSData/Input/Squadron/I_JG52.json
@@ -4,6 +4,7 @@
   "name": "I./JG52",
   "fileName": "I_JG52.json",
   "skill": 85,
+  "subUnitIdCode": "",
   "planeAssignments": [
     {
       "archType": "bf109",

--- a/BoSData/Input/Squadron/I_JG6.json
+++ b/BoSData/Input/Squadron/I_JG6.json
@@ -4,6 +4,7 @@
   "name": "I./JG6",
   "fileName": "I_JG6.json",
   "skill": 70,
+  "subUnitIdCode": "",
   "planeAssignments": [
     {
       "archType": "fw190",

--- a/BoSData/Input/Squadron/I_JG77.json
+++ b/BoSData/Input/Squadron/I_JG77.json
@@ -4,6 +4,7 @@
   "name": "I./JG77",
   "fileName": "I_JG77.json",
   "skill": 70,
+  "subUnitIdCode": "",
   "planeAssignments": [
     {
       "archType": "bf109",

--- a/BoSData/Input/Squadron/I_KG51.json
+++ b/BoSData/Input/Squadron/I_KG51.json
@@ -4,6 +4,8 @@
   "name": "I./KG51",
   "fileName": "I_KG51.json",
   "skill": 60,
+  "unitIdCode": "9K",
+  "subUnitIdCode": "K",
   "planeAssignments": [
     {
       "archType": "me262",

--- a/BoSData/Input/Squadron/I_KG53.json
+++ b/BoSData/Input/Squadron/I_KG53.json
@@ -4,6 +4,8 @@
 	"name": "I./KG53",
 	"fileName": "I_KG53.json",
 	"skill": 50,
+	"unitIdCode": "A1",
+	"subUnitIdCode": "L",
 	"planeAssignments": [
 		{
 			"archType": "he111",
@@ -93,13 +95,17 @@
 				"date": "19420301",
 				"squadName": "I./KG27",
 				"armedServiceName": "Luftwaffe",
-				"skill": 50
+				"skill": 50,
+				"unitIdCode": "1G",
+				"subUnitIdCode": "L"
 			},
 			{
 				"date": "19430918",
 				"squadName": "I./KG4",
 				"armedServiceName": "Luftwaffe",
-				"skill": 40
+				"skill": 40,
+				"unitIdCode": "5J",
+				"subUnitIdCode": "L"
 			}
 		]
 	},

--- a/BoSData/Input/Squadron/I_KG54.json
+++ b/BoSData/Input/Squadron/I_KG54.json
@@ -4,6 +4,8 @@
   "name": "I./KG54",
   "fileName": "I_KG54.json",
   "skill": 50,
+  "unitIdCode": "B3",
+  "subUnitIdCode": "L",
   "planeAssignments": [
     {
       "archType": "ju88",

--- a/BoSData/Input/Squadron/I_KG76.json
+++ b/BoSData/Input/Squadron/I_KG76.json
@@ -4,6 +4,8 @@
   "name": "I./KG76",
   "fileName": "I_KG76.json",
   "skill": 50,
+  "unitIdCode": "F1",
+  "subUnitIdCode": "L",
   "planeAssignments": [
     {
       "archType": "ju88",
@@ -83,7 +85,9 @@
         "date": "19430918",
         "squadName": "I./KG51",
         "armedServiceName": "Luftwaffe",
-        "skill": 40
+        "skill": 40,
+        "unitIdCode": "9K",
+        "subUnitIdCode": "L"
       }
     ]
   },

--- a/BoSData/Input/Squadron/I_St_G_2.json
+++ b/BoSData/Input/Squadron/I_St_G_2.json
@@ -4,6 +4,8 @@
 	"name": "I./St.G.2",
 	"fileName": "I_St_G_2.json",
 	"skill": 60,
+	"unitIdCode": "T6",
+	"subUnitIdCode": "K",
 	"planeAssignments": [
 		{
 			"archType": "ju87",
@@ -83,7 +85,8 @@
 				"date": "19431018",
 				"squadName": "I./SG2",
 				"armedServiceName": "Luftwaffe",
-				"skill": 55
+				"skill": 55,
+				"subUnitIdCode": "-"
 			}
 		]
 	},

--- a/BoSData/Input/Squadron/I_St_G_77.json
+++ b/BoSData/Input/Squadron/I_St_G_77.json
@@ -4,6 +4,8 @@
 	"name": "I./St.G.77",
 	"fileName": "I_St_G_77.json",
 	"skill": 65,
+	"unitIdCode": "S2",
+	"subUnitIdCode": "H",
 	"planeAssignments": [
 		{
 			"archType": "ju87",
@@ -88,7 +90,9 @@
 				"date": "19431018",
 				"squadName": "I./SG77",
 				"armedServiceName": "Luftwaffe",
-				"skill": 60
+				"skill": 60,
+				"unitIdCode": "S2",
+				"subUnitIdCode": "H"
 			}
 		]
 	},

--- a/BoSData/Input/Squadron/I_ZG26.json
+++ b/BoSData/Input/Squadron/I_ZG26.json
@@ -4,6 +4,8 @@
   "name": "I./ZG 26",
   "fileName": "I_ZG26.json",
   "skill": 70,
+  "unitIdCode": "3U",
+  "subUnitIdCode": "L",
   "planeAssignments": [
     {
       "archType": "bf110",

--- a/BoSData/Input/Squadron/JV44.json
+++ b/BoSData/Input/Squadron/JV44.json
@@ -4,6 +4,7 @@
   "name": "JV44",
   "fileName": "JV44.json",
   "skill": 95,
+  "subUnitIdCode": "",
   "planeAssignments": [
     {
       "archType": "me262",

--- a/BoSData/Input/Squadron/KGrzbV800.json
+++ b/BoSData/Input/Squadron/KGrzbV800.json
@@ -4,6 +4,8 @@
   "name": "KGrzbV800",
   "fileName": "KGrzbV800.json",
   "skill": 50,
+  "unitIdCode": "3T",
+  "subUnitIdCode": "M",
   "planeAssignments": [
     {
       "archType": "ju52",
@@ -62,7 +64,9 @@
         "date": "19430501",
         "squadName": "II./TG2",
         "armedServiceName": "Luftwaffe",
-        "skill": 50
+        "skill": 50,
+        "unitIdCode": "8T",
+        "subUnitIdCode": "S"
       }
     ]
   },

--- a/src/main/java/pwcg/aar/campaign/update/EquipmentUpdater.java
+++ b/src/main/java/pwcg/aar/campaign/update/EquipmentUpdater.java
@@ -2,6 +2,7 @@ package pwcg.aar.campaign.update;
 
 import pwcg.aar.data.AARContext;
 import pwcg.campaign.Campaign;
+import pwcg.campaign.context.PWCGContext;
 import pwcg.campaign.plane.Equipment;
 import pwcg.campaign.plane.EquippedPlane;
 import pwcg.campaign.plane.PlaneStatus;
@@ -35,7 +36,7 @@ public class EquipmentUpdater
         }
     }
 
-    private void equipmentAdditions()
+    private void equipmentAdditions() throws PWCGException
     {
         for (EquipmentResupplyRecord equipmentResupplyRecord : aarContext.getCampaignUpdateData().getResupplyData().getEquipmentResupplyData().getEquipmentResupplied())
         {
@@ -43,6 +44,7 @@ public class EquipmentUpdater
             EquippedPlane replacementPlane = equipmentResupplyRecord.getEquippedPlane();
             replacementPlane.setSquadronId(equipmentResupplyRecord.getTransferTo());
             replacementPlane.setPlaneStatus(PlaneStatus.STATUS_DEPLOYED);
+            PWCGContext.getInstance().getPlaneMarkingManager().allocatePlaneIdCode(campaign, equipmentResupplyRecord.getTransferTo(), equipment, replacementPlane);
             equipment.addEquippedPlane(replacementPlane);
         }
     }

--- a/src/main/java/pwcg/campaign/CampaignEquipmentManager.java
+++ b/src/main/java/pwcg/campaign/CampaignEquipmentManager.java
@@ -177,6 +177,7 @@ public class CampaignEquipmentManager
             PlaneTypeFactory planeTypeFactory = PWCGContext.getInstance().getPlaneTypeFactory();
             PlaneType planeType = planeTypeFactory.getPlaneByDisplayName(planeTypeToChangeTo);
             EquippedPlane equippedPlane = new EquippedPlane(planeType, campaign.getSerialNumber().getNextPlaneSerialNumber(), squadron.getSquadronId(), PlaneStatus.STATUS_DEPLOYED);
+            PWCGContext.getInstance().getPlaneMarkingManager().allocatePlaneIdCode(campaign, squadron.getSquadronId(), squadronEquipment, equippedPlane);
             squadronEquipment.addEquippedPlane(equippedPlane);
         }
     }

--- a/src/main/java/pwcg/campaign/EmergencyResupplyHandler.java
+++ b/src/main/java/pwcg/campaign/EmergencyResupplyHandler.java
@@ -116,6 +116,7 @@ public class EmergencyResupplyHandler
         String planeTypeName = determinePlaneTypeToAdd(squadronId);
         PlaneEquipmentFactory equipmentFactory = new PlaneEquipmentFactory(campaign);
         EquippedPlane equippedPlane = equipmentFactory.makePlaneForDepot(planeTypeName);
+        PWCGContext.getInstance().getPlaneMarkingManager().allocatePlaneIdCode(campaign, squadronId, squadronEquipment, equippedPlane);
         squadronEquipment.addEquippedPlane(equippedPlane);
     }
 

--- a/src/main/java/pwcg/campaign/SquadHistoryEntry.java
+++ b/src/main/java/pwcg/campaign/SquadHistoryEntry.java
@@ -7,6 +7,8 @@ public class SquadHistoryEntry
     private String squadName = "";
 	private String armedServiceName = "";
 	private int skill = NO_SQUADRON_SKILL_CHANGE;
+	private String unitIdCode;
+	private String subUnitIdCode;
     
 	public String getDate()
     {
@@ -46,5 +48,25 @@ public class SquadHistoryEntry
     public void setSkill(int skill)
     {
         this.skill = skill;
+    }
+
+    public String getUnitIdCode()
+    {
+        return unitIdCode;
+    }
+
+    public void setUnitIdCode(String unitIdCode)
+    {
+        this.unitIdCode = unitIdCode;
+    }
+
+    public String getSubUnitIdCode()
+    {
+        return subUnitIdCode;
+    }
+
+    public void setSubUnitIdCode(String subUnitIdCode)
+    {
+        this.subUnitIdCode = subUnitIdCode;
     }
 }

--- a/src/main/java/pwcg/campaign/context/BehindEnemyLines.java
+++ b/src/main/java/pwcg/campaign/context/BehindEnemyLines.java
@@ -3,7 +3,6 @@ package pwcg.campaign.context;
 import java.util.Date;
 
 import pwcg.campaign.api.Side;
-import pwcg.campaign.context.FrontMapIdentifier;
 import pwcg.campaign.group.airfield.Airfield;
 import pwcg.core.exception.PWCGException;
 import pwcg.core.location.Coordinate;

--- a/src/main/java/pwcg/campaign/context/BoSContext.java
+++ b/src/main/java/pwcg/campaign/context/BoSContext.java
@@ -1,7 +1,9 @@
 package pwcg.campaign.context;
 
+import pwcg.campaign.plane.IPlaneMarkingManager;
 import pwcg.campaign.plane.payload.IPayloadFactory;
 import pwcg.core.exception.PWCGException;
+import pwcg.product.bos.plane.BoSPlaneMarkingManager;
 import pwcg.product.bos.plane.payload.BoSPayloadFactory;
 
 public class BoSContext extends PWCGContextBase implements IPWCGContextManager
@@ -87,5 +89,11 @@ public class BoSContext extends PWCGContextBase implements IPWCGContextManager
     public PWCGDirectoryProductManager getDirectoryManager()
     {
         return new PWCGDirectoryProductManager(PWCGProduct.BOS);
+    }
+
+    @Override
+    public IPlaneMarkingManager getPlaneMarkingManager()
+    {
+        return new BoSPlaneMarkingManager();
     }
 }

--- a/src/main/java/pwcg/campaign/context/FCContext.java
+++ b/src/main/java/pwcg/campaign/context/FCContext.java
@@ -1,11 +1,14 @@
 package pwcg.campaign.context;
 
+import java.io.BufferedWriter;
+
 import pwcg.campaign.Campaign;
 import pwcg.campaign.plane.Equipment;
 import pwcg.campaign.plane.EquippedPlane;
 import pwcg.campaign.plane.IPlaneMarkingManager;
 import pwcg.campaign.plane.payload.IPayloadFactory;
 import pwcg.core.exception.PWCGException;
+import pwcg.mission.flight.plane.PlaneMcu;
 import pwcg.product.fc.plane.payload.FCPayloadFactory;
 
 public class FCContext extends PWCGContextBase implements IPWCGContextManager
@@ -69,6 +72,11 @@ public class FCContext extends PWCGContextBase implements IPWCGContextManager
             public String determineDisplayMarkings(Campaign campaign, EquippedPlane equippedPlane) throws PWCGException
             {
                 return Integer.toString(equippedPlane.getSerialNumber());
+            }
+
+            @Override
+            public void writeTacticalCodes(BufferedWriter writer, Campaign campaign, PlaneMcu equippedPlane) throws PWCGException
+            {
             }
         };
     }

--- a/src/main/java/pwcg/campaign/context/FCContext.java
+++ b/src/main/java/pwcg/campaign/context/FCContext.java
@@ -64,6 +64,12 @@ public class FCContext extends PWCGContextBase implements IPWCGContextManager
             @Override
             public void allocatePlaneIdCode(Campaign campaign, int squadronId, Equipment equipment, EquippedPlane equippedPlane) throws PWCGException {
             }
+
+            @Override
+            public String determineDisplayMarkings(Campaign campaign, EquippedPlane equippedPlane) throws PWCGException
+            {
+                return Integer.toString(equippedPlane.getSerialNumber());
+            }
         };
     }
 }

--- a/src/main/java/pwcg/campaign/context/FCContext.java
+++ b/src/main/java/pwcg/campaign/context/FCContext.java
@@ -1,6 +1,5 @@
 package pwcg.campaign.context;
 
-import pwcg.campaign.context.FrontMapIdentifier;
 import pwcg.campaign.plane.payload.IPayloadFactory;
 import pwcg.core.exception.PWCGException;
 import pwcg.product.fc.plane.payload.FCPayloadFactory;

--- a/src/main/java/pwcg/campaign/context/FCContext.java
+++ b/src/main/java/pwcg/campaign/context/FCContext.java
@@ -1,5 +1,9 @@
 package pwcg.campaign.context;
 
+import pwcg.campaign.Campaign;
+import pwcg.campaign.plane.Equipment;
+import pwcg.campaign.plane.EquippedPlane;
+import pwcg.campaign.plane.IPlaneMarkingManager;
 import pwcg.campaign.plane.payload.IPayloadFactory;
 import pwcg.core.exception.PWCGException;
 import pwcg.product.fc.plane.payload.FCPayloadFactory;
@@ -51,5 +55,15 @@ public class FCContext extends PWCGContextBase implements IPWCGContextManager
     public PWCGDirectoryProductManager getDirectoryManager()
     {
         return new PWCGDirectoryProductManager(PWCGProduct.FC);
+    }
+
+    @Override
+    public IPlaneMarkingManager getPlaneMarkingManager()
+    {
+         return new IPlaneMarkingManager() {
+            @Override
+            public void allocatePlaneIdCode(Campaign campaign, int squadronId, Equipment equipment, EquippedPlane equippedPlane) throws PWCGException {
+            }
+        };
     }
 }

--- a/src/main/java/pwcg/campaign/context/FrontDatesForMap.java
+++ b/src/main/java/pwcg/campaign/context/FrontDatesForMap.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import pwcg.campaign.context.FrontMapIdentifier;
 import pwcg.core.exception.PWCGException;
 import pwcg.core.utils.DateRange;
 import pwcg.core.utils.DateUtils;

--- a/src/main/java/pwcg/campaign/context/IPWCGContextManager.java
+++ b/src/main/java/pwcg/campaign/context/IPWCGContextManager.java
@@ -6,6 +6,7 @@ import java.util.List;
 import pwcg.campaign.Campaign;
 import pwcg.campaign.group.airfield.Airfield;
 import pwcg.campaign.group.airfield.staticobject.StaticObjectDefinitionManager;
+import pwcg.campaign.plane.IPlaneMarkingManager;
 import pwcg.campaign.plane.PlaneTypeFactory;
 import pwcg.campaign.plane.payload.IPayloadFactory;
 import pwcg.campaign.skin.SkinManager;
@@ -71,4 +72,6 @@ public interface IPWCGContextManager
     String getMissionLogDirectory();
 
     void setCurrentMap(FrontMapIdentifier bodenplatteMap) throws PWCGException;
+
+    IPlaneMarkingManager getPlaneMarkingManager();
 }

--- a/src/main/java/pwcg/campaign/context/MapFinderForCampaign.java
+++ b/src/main/java/pwcg/campaign/context/MapFinderForCampaign.java
@@ -3,7 +3,6 @@ package pwcg.campaign.context;
 import java.util.List;
 
 import pwcg.campaign.Campaign;
-import pwcg.campaign.context.FrontMapIdentifier;
 import pwcg.campaign.squadmember.SquadronMember;
 import pwcg.campaign.squadmember.SquadronMembers;
 import pwcg.campaign.squadron.Squadron;

--- a/src/main/java/pwcg/campaign/context/MapForAirfieldFinder.java
+++ b/src/main/java/pwcg/campaign/context/MapForAirfieldFinder.java
@@ -3,7 +3,6 @@ package pwcg.campaign.context;
 import java.util.ArrayList;
 import java.util.List;
 
-import pwcg.campaign.context.FrontMapIdentifier;
 import pwcg.campaign.group.AirfieldManager;
 import pwcg.campaign.group.airfield.Airfield;
 

--- a/src/main/java/pwcg/campaign/context/PWCGMapFactory.java
+++ b/src/main/java/pwcg/campaign/context/PWCGMapFactory.java
@@ -1,6 +1,5 @@
 package pwcg.campaign.context;
 
-import pwcg.campaign.context.FrontMapIdentifier;
 import pwcg.core.exception.PWCGException;
 import pwcg.product.bos.map.bodenplatte.BodenplatteMap;
 import pwcg.product.bos.map.east1944.East1944Map;

--- a/src/main/java/pwcg/campaign/context/StalingradMapResolver.java
+++ b/src/main/java/pwcg/campaign/context/StalingradMapResolver.java
@@ -1,7 +1,6 @@
 package pwcg.campaign.context;
 
 import pwcg.campaign.Campaign;
-import pwcg.campaign.context.FrontMapIdentifier;
 import pwcg.core.exception.PWCGException;
 import pwcg.core.utils.DateUtils;
 

--- a/src/main/java/pwcg/campaign/io/json/CampaignEquipmentIOJson.java
+++ b/src/main/java/pwcg/campaign/io/json/CampaignEquipmentIOJson.java
@@ -8,6 +8,7 @@ import pwcg.campaign.context.PWCGContext;
 import pwcg.campaign.context.PWCGDirectoryUserManager;
 import pwcg.campaign.plane.Equipment;
 import pwcg.campaign.plane.EquippedPlane;
+import pwcg.campaign.plane.PlaneType;
 import pwcg.campaign.resupply.depot.EquipmentDepot;
 import pwcg.core.exception.PWCGException;
 import pwcg.core.utils.FileUtils;
@@ -93,6 +94,12 @@ public class CampaignEquipmentIOJson
             EquipmentDepot replacementEquipemnt = jsoReader.readJsonFile(campaignEquipmentReplacementDir, jsonFile.getName());
             int serviceId = Integer.valueOf(FileUtils.stripFileExtension(jsonFile.getName()));
             campaign.getEquipmentManager().addEquipmentDepotForService(serviceId, replacementEquipemnt);
+            for (EquippedPlane equippedPlane : replacementEquipemnt.getAllPlanesInDepot())
+            {
+                // Propagate any updates to the aircraft definitions into plane instances
+                PlaneType basePlane = PWCGContext.getInstance().getPlaneTypeFactory().getPlaneById(equippedPlane.getType());
+                basePlane.copyTemplate(equippedPlane);
+            }
         }
     }
 }

--- a/src/main/java/pwcg/campaign/io/json/CampaignEquipmentIOJson.java
+++ b/src/main/java/pwcg/campaign/io/json/CampaignEquipmentIOJson.java
@@ -4,8 +4,10 @@ import java.io.File;
 import java.util.List;
 
 import pwcg.campaign.Campaign;
+import pwcg.campaign.context.PWCGContext;
 import pwcg.campaign.context.PWCGDirectoryUserManager;
 import pwcg.campaign.plane.Equipment;
+import pwcg.campaign.plane.EquippedPlane;
 import pwcg.campaign.resupply.depot.EquipmentDepot;
 import pwcg.core.exception.PWCGException;
 import pwcg.core.utils.FileUtils;
@@ -72,6 +74,12 @@ public class CampaignEquipmentIOJson
             Equipment squadronEquipment = jsoReader.readJsonFile(campaignEquipmentDir, jsonFile.getName());
             int squadronId = Integer.valueOf(FileUtils.stripFileExtension(jsonFile.getName()));
             campaign.getEquipmentManager().addEquipmentForSquadron(squadronId, squadronEquipment);
+            // Allocate ID codes in case none were present
+            for (EquippedPlane equippedPlane : squadronEquipment.getActiveEquippedPlanes().values())
+            {
+                if (equippedPlane.getAircraftIdCode() == null)
+                    PWCGContext.getInstance().getPlaneMarkingManager().allocatePlaneIdCode(campaign, squadronId, squadronEquipment, equippedPlane);
+            }
         }
     }
 

--- a/src/main/java/pwcg/campaign/plane/Equipment.java
+++ b/src/main/java/pwcg/campaign/plane/Equipment.java
@@ -74,11 +74,6 @@ public class Equipment
         }
     }
 
-    public void setEquippedPlanes(Map<Integer, EquippedPlane> equippedPlanes)
-    {
-        this.equippedPlanes = equippedPlanes;
-    }
-
     public void addEquippedPlane(EquippedPlane equippedPlane)
     {
         equippedPlanes.put(equippedPlane.getSerialNumber(), equippedPlane);

--- a/src/main/java/pwcg/campaign/plane/EquippedPlane.java
+++ b/src/main/java/pwcg/campaign/plane/EquippedPlane.java
@@ -10,6 +10,7 @@ public class EquippedPlane extends PlaneType
     protected int planeStatus = PlaneStatus.NO_STATUS;
     protected int squadronId;
     protected Date dateRemovedFromService;
+    protected String aircraftIdCode;
 
     public EquippedPlane()
     {
@@ -32,6 +33,7 @@ public class EquippedPlane extends PlaneType
         equippedPlane.squadronId = this.squadronId;
         equippedPlane.dateRemovedFromService = this.dateRemovedFromService;
         equippedPlane.planeStatus = this.planeStatus;
+        equippedPlane.aircraftIdCode = this.aircraftIdCode;
     }
     
     public int getSerialNumber()
@@ -72,5 +74,15 @@ public class EquippedPlane extends PlaneType
     public void setSquadronId(int squadronId)
     {
         this.squadronId = squadronId;
+    }
+
+    public String getAircraftIdCode()
+    {
+        return aircraftIdCode;
+    }
+
+    public void setAircraftIdCode(String aircraftIdCode)
+    {
+        this.aircraftIdCode = aircraftIdCode;
     }
 }

--- a/src/main/java/pwcg/campaign/plane/EquippedPlane.java
+++ b/src/main/java/pwcg/campaign/plane/EquippedPlane.java
@@ -2,7 +2,10 @@ package pwcg.campaign.plane;
 
 import java.util.Date;
 
+import pwcg.campaign.Campaign;
+import pwcg.campaign.context.PWCGContext;
 import pwcg.campaign.squadmember.SerialNumber;
+import pwcg.core.exception.PWCGException;
 
 public class EquippedPlane extends PlaneType
 {
@@ -84,5 +87,10 @@ public class EquippedPlane extends PlaneType
     public void setAircraftIdCode(String aircraftIdCode)
     {
         this.aircraftIdCode = aircraftIdCode;
+    }
+
+    public String getDisplayMarkings() throws PWCGException {
+        Campaign campaign = PWCGContext.getInstance().getCampaign();
+        return PWCGContext.getInstance().getPlaneMarkingManager().determineDisplayMarkings(campaign, this);
     }
 }

--- a/src/main/java/pwcg/campaign/plane/IPlaneMarkingManager.java
+++ b/src/main/java/pwcg/campaign/plane/IPlaneMarkingManager.java
@@ -1,0 +1,8 @@
+package pwcg.campaign.plane;
+
+import pwcg.campaign.Campaign;
+import pwcg.core.exception.PWCGException;
+
+public interface IPlaneMarkingManager {
+    public void allocatePlaneIdCode(Campaign campaign, int squadronId, Equipment equipment, EquippedPlane equippedPlane) throws PWCGException;
+}

--- a/src/main/java/pwcg/campaign/plane/IPlaneMarkingManager.java
+++ b/src/main/java/pwcg/campaign/plane/IPlaneMarkingManager.java
@@ -1,10 +1,15 @@
 package pwcg.campaign.plane;
 
+import java.io.BufferedWriter;
+
 import pwcg.campaign.Campaign;
 import pwcg.core.exception.PWCGException;
+import pwcg.mission.flight.plane.PlaneMcu;
 
 public interface IPlaneMarkingManager {
     public void allocatePlaneIdCode(Campaign campaign, int squadronId, Equipment equipment, EquippedPlane equippedPlane) throws PWCGException;
 
     public String determineDisplayMarkings(Campaign campaign, EquippedPlane equippedPlane) throws PWCGException;
+
+    public void writeTacticalCodes(BufferedWriter writer, Campaign campaign, PlaneMcu equippedPlane) throws PWCGException;
 }

--- a/src/main/java/pwcg/campaign/plane/IPlaneMarkingManager.java
+++ b/src/main/java/pwcg/campaign/plane/IPlaneMarkingManager.java
@@ -5,4 +5,6 @@ import pwcg.core.exception.PWCGException;
 
 public interface IPlaneMarkingManager {
     public void allocatePlaneIdCode(Campaign campaign, int squadronId, Equipment equipment, EquippedPlane equippedPlane) throws PWCGException;
+
+    public String determineDisplayMarkings(Campaign campaign, EquippedPlane equippedPlane) throws PWCGException;
 }

--- a/src/main/java/pwcg/campaign/plane/PlaneType.java
+++ b/src/main/java/pwcg/campaign/plane/PlaneType.java
@@ -12,6 +12,7 @@ import pwcg.campaign.api.Side;
 import pwcg.campaign.context.Country;
 import pwcg.campaign.factory.ProductSpecificConfigurationFactory;
 import pwcg.campaign.plane.payload.PayloadElement;
+import pwcg.campaign.skin.TacticalCodeColor;
 import pwcg.core.exception.PWCGException;
 import pwcg.core.exception.PWCGIOException;
 import pwcg.core.utils.PWCGLogger;
@@ -45,6 +46,7 @@ public class PlaneType implements Cloneable
     protected Side side = null;
     protected List<Country> primaryUsedBy = new ArrayList<>();
     protected List<PayloadElement> stockModifications = new ArrayList<>();
+    protected TacticalCodeColor tacticalCodeColor = TacticalCodeColor.BLACK;
 
 
     public PlaneType()
@@ -84,6 +86,7 @@ public class PlaneType implements Cloneable
 
         planeType.side = this.side;
         planeType.primaryUsedBy = new ArrayList<>(this.primaryUsedBy);
+        planeType.tacticalCodeColor = this.tacticalCodeColor;
     }
 
     public int getCruisingSpeed()
@@ -399,4 +402,10 @@ public class PlaneType implements Cloneable
     {
         return primaryUsedBy;
     }
+
+    public TacticalCodeColor getTacticalCodeColor()
+    {
+        return tacticalCodeColor;
+    }
+
 }

--- a/src/main/java/pwcg/campaign/plane/PlaneType.java
+++ b/src/main/java/pwcg/campaign/plane/PlaneType.java
@@ -80,8 +80,10 @@ public class PlaneType implements Cloneable
 
         planeType.introduction = this.introduction;
         planeType.withdrawal = this.withdrawal;
+        planeType.endProduction = this.endProduction;
 
         planeType.side = this.side;
+        planeType.primaryUsedBy = new ArrayList<>(this.primaryUsedBy);
     }
 
     public int getCruisingSpeed()

--- a/src/main/java/pwcg/campaign/resupply/InitialSquadronEquipper.java
+++ b/src/main/java/pwcg/campaign/resupply/InitialSquadronEquipper.java
@@ -59,6 +59,7 @@ public class InitialSquadronEquipper
             
             PlaneEquipmentFactory equipmentFactory = new PlaneEquipmentFactory(campaign);
             EquippedPlane equippedPlane = equipmentFactory.makePlaneForSquadron(planeTypeName, squadron.getSquadronId());
+            PWCGContext.getInstance().getPlaneMarkingManager().allocatePlaneIdCode(campaign, squadron.getSquadronId(), equipment, equippedPlane);
             equipment.addEquippedPlane(equippedPlane);
         }
     }

--- a/src/main/java/pwcg/campaign/resupply/depot/EquipmentArchTypeChangeHandler.java
+++ b/src/main/java/pwcg/campaign/resupply/depot/EquipmentArchTypeChangeHandler.java
@@ -74,6 +74,7 @@ public class EquipmentArchTypeChangeHandler
             {
                 PlaneEquipmentFactory equipmentFactory = new PlaneEquipmentFactory(campaign);
                 EquippedPlane replacementPlane = equipmentFactory.makePlaneForSquadron(bestPlaneType.getType(), squadron.getSquadronId());
+                PWCGContext.getInstance().getPlaneMarkingManager().allocatePlaneIdCode(campaign, squadron.getSquadronId(), squadronEquipment, replacementPlane);
                 squadronEquipment.addEquippedPlane(replacementPlane);
             }
         }

--- a/src/main/java/pwcg/campaign/resupply/equipment/EquipmentUpgradeHandler.java
+++ b/src/main/java/pwcg/campaign/resupply/equipment/EquipmentUpgradeHandler.java
@@ -10,6 +10,7 @@ import pwcg.campaign.Campaign;
 import pwcg.campaign.context.PWCGContext;
 import pwcg.campaign.plane.Equipment;
 import pwcg.campaign.plane.EquippedPlane;
+import pwcg.campaign.plane.IPlaneMarkingManager;
 import pwcg.campaign.plane.PlaneSorter;
 import pwcg.campaign.resupply.depot.EquipmentDepot;
 import pwcg.campaign.resupply.depot.EquipmentUpgradeRecord;
@@ -62,6 +63,7 @@ public class EquipmentUpgradeHandler
     {
         Equipment equipmentForSquadron = campaign.getEquipmentManager().getEquipmentForSquadron(squadron.getSquadronId());
         EquipmentDepot equipmentDepot = campaign.getEquipmentManager().getEquipmentDepotForService(squadron.getService());
+        IPlaneMarkingManager planeMarkingManager = PWCGContext.getInstance().getPlaneMarkingManager();
 
         List<EquippedPlane> sortedPlanes = getPlanesForSquadronWorstToBest(equipmentForSquadron);
         for (EquippedPlane equippedPlane : sortedPlanes)
@@ -70,6 +72,7 @@ public class EquipmentUpgradeHandler
             if (equipmentUpgrade != null)
             {
                 EquippedPlane replacementPlane = equipmentDepot.removeEquippedPlaneFromDepot(equipmentUpgrade.getUpgrade().getSerialNumber());
+                planeMarkingManager.allocatePlaneIdCode(campaign, squadron.getSquadronId(), equipmentForSquadron, equippedPlane);
                 equipmentForSquadron.addEquippedPlane(replacementPlane);
                 
                 EquippedPlane replacedPlane = equipmentForSquadron.removeEquippedPlane(equipmentUpgrade.getReplacedPlane().getSerialNumber());

--- a/src/main/java/pwcg/campaign/resupply/equipment/WithdrawnEquipmentReplacer.java
+++ b/src/main/java/pwcg/campaign/resupply/equipment/WithdrawnEquipmentReplacer.java
@@ -7,6 +7,7 @@ import pwcg.campaign.Campaign;
 import pwcg.campaign.context.PWCGContext;
 import pwcg.campaign.plane.Equipment;
 import pwcg.campaign.plane.EquippedPlane;
+import pwcg.campaign.plane.IPlaneMarkingManager;
 import pwcg.campaign.plane.PlaneArchType;
 import pwcg.campaign.plane.PlaneEquipmentFactory;
 import pwcg.campaign.resupply.depot.EquipmentReplacementUtils;
@@ -126,8 +127,10 @@ public class WithdrawnEquipmentReplacer
 
     private void addPlaneToSquadron(String planeTypeName) throws PWCGException
     {
+        IPlaneMarkingManager planeMarkingManager = PWCGContext.getInstance().getPlaneMarkingManager();
         PlaneEquipmentFactory equipmentFactory = new PlaneEquipmentFactory(campaign);
         EquippedPlane equippedPlane = equipmentFactory.makePlaneForSquadron(planeTypeName, squadron.getSquadronId());
+        planeMarkingManager.allocatePlaneIdCode(campaign, squadron.getSquadronId(), equipment, equippedPlane);
         equipment.addEquippedPlane(equippedPlane);
     }
 }

--- a/src/main/java/pwcg/campaign/skin/Skin.java
+++ b/src/main/java/pwcg/campaign/skin/Skin.java
@@ -22,6 +22,8 @@ public class Skin implements Cloneable
     private String category = "";
     private boolean definedInGame = false;
     private boolean winter = false;
+    private boolean useTacticalCodes = false;
+    private TacticalCodeColor tacticalCodeColor = TacticalCodeColor.BLACK;
 	
     public static int FACTORY_GENERIC = -2;
     public static int PERSONAL_SKIN = -1;
@@ -48,6 +50,8 @@ public class Skin implements Cloneable
 			skin.category = this.category;
             skin.definedInGame = this.definedInGame;
             skin.winter = this.winter;
+            skin.useTacticalCodes = this.useTacticalCodes;
+            skin.tacticalCodeColor = this.tacticalCodeColor;
 		}
 		catch (Exception e)
 		{
@@ -170,5 +174,15 @@ public class Skin implements Cloneable
     public void setWinter(boolean winter)
     {
         this.winter = winter;
+    }
+
+    public boolean isUseTacticalCodes()
+    {
+        return useTacticalCodes;
+    }
+
+    public TacticalCodeColor getTacticalCodeColor()
+    {
+        return tacticalCodeColor;
     }
 }

--- a/src/main/java/pwcg/campaign/skin/TacticalCodeColor.java
+++ b/src/main/java/pwcg/campaign/skin/TacticalCodeColor.java
@@ -1,0 +1,24 @@
+package pwcg.campaign.skin;
+
+public enum TacticalCodeColor
+{
+    BLACK("0"),
+    WHITE("1"),
+    RED("2"),
+    BLUE("3"),
+    YELLOW("4"),
+    GREEN("5"),
+    SKY("6");
+
+    private String colorStr;
+
+    TacticalCodeColor(String str)
+    {
+        colorStr = str;
+    }
+
+    public String getColorCode()
+    {
+        return colorStr;
+    }
+}

--- a/src/main/java/pwcg/campaign/squadron/Squadron.java
+++ b/src/main/java/pwcg/campaign/squadron/Squadron.java
@@ -59,6 +59,8 @@ public class Squadron
     private String name = "";
     private String fileName = "";
 	private int skill = 50;
+	private String unitIdCode;
+	private String subUnitIdCode;
 	private List<SquadronPlaneAssignment> planeAssignments = new ArrayList<>();
     private Map<Date, String> airfields = new TreeMap<>();
 	private List<Skin> skins = new ArrayList<Skin>();
@@ -794,5 +796,37 @@ public class Squadron
     public SpecializedRole getActiveSpecializedRole(Date date) throws PWCGException
     {
         return squadronSpecializedRoles.selectSpecializedRoleForMission(date);
+    }
+
+    public String determineUnitIdCode(Date date) throws PWCGException
+    {
+        String code = unitIdCode;
+
+        if (date != null)
+        {
+            SquadHistoryEntry squadHistoryEntry = getSquadronHistoryEntryForDate(date);
+            if (squadHistoryEntry != null)
+            {
+                code = squadHistoryEntry.getUnitIdCode();
+            }
+        }
+
+        return code;
+    }
+
+    public String determineSubUnitIdCode(Date date) throws PWCGException
+    {
+        String code = subUnitIdCode;
+
+        if (date != null)
+        {
+            SquadHistoryEntry squadHistoryEntry = getSquadronHistoryEntryForDate(date);
+            if (squadHistoryEntry != null)
+            {
+                code = squadHistoryEntry.getSubUnitIdCode();
+            }
+        }
+
+        return code;
     }
 }

--- a/src/main/java/pwcg/gui/campaign/home/CampaignEquipmentChalkboard.java
+++ b/src/main/java/pwcg/gui/campaign/home/CampaignEquipmentChalkboard.java
@@ -13,7 +13,9 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 
 import pwcg.campaign.Campaign;
+import pwcg.campaign.context.PWCGContext;
 import pwcg.campaign.plane.EquippedPlane;
+import pwcg.campaign.plane.IPlaneMarkingManager;
 import pwcg.campaign.plane.PlaneSorter;
 import pwcg.campaign.squadmember.SquadronMember;
 import pwcg.core.exception.PWCGException;
@@ -48,13 +50,14 @@ public class CampaignEquipmentChalkboard extends ImageResizingPanel
         SquadronMember referencePlayer = campaign.findReferencePlayer();            
         Map<Integer, EquippedPlane> planesForSquadron = campaign.getEquipmentManager().getEquipmentForSquadron(referencePlayer.getSquadronId()).getActiveEquippedPlanes();
         
-        JPanel equipmentPanel = createEquipmentListPanel(planesForSquadron);
+        JPanel equipmentPanel = createEquipmentListPanel(campaign, planesForSquadron);
         this.add(equipmentPanel, BorderLayout.CENTER);
     }
 
-    private JPanel createEquipmentListPanel(Map<Integer, EquippedPlane> planesForSquadron) throws PWCGException
+    private JPanel createEquipmentListPanel(Campaign campaign, Map<Integer, EquippedPlane> planesForSquadron) throws PWCGException
     {
         List<EquippedPlane> sortedAircraftOnInventory = PlaneSorter.sortEquippedPlanesByGoodness(new ArrayList<EquippedPlane>(planesForSquadron.values()));
+        IPlaneMarkingManager planeMarkingManager = PWCGContext.getInstance().getPlaneMarkingManager();
 
         Color buttonBG = ColorMap.CHALK_BACKGROUND;
         Color buttonFG = ColorMap.CHALK_FOREGROUND;
@@ -98,7 +101,7 @@ public class CampaignEquipmentChalkboard extends ImageResizingPanel
         constraints.gridy = 0;
         equipmentChalkboardPanel.add(lMissionHeader, constraints);
 
-        JLabel lVictoryHeader = new JLabel("      ", JLabel.RIGHT);
+        JLabel lVictoryHeader = new JLabel("ID Code", JLabel.RIGHT);
         lVictoryHeader.setOpaque(false);
         lVictoryHeader.setForeground(buttonFG);
         lVictoryHeader.setFont(font);
@@ -146,14 +149,13 @@ public class CampaignEquipmentChalkboard extends ImageResizingPanel
             constraints.gridy = i;
             equipmentChalkboardPanel.add(aircraftSerialNumberLabel, constraints);
             
-            
-            lDummy = new JLabel("     ");
-            lDummy.setOpaque(false);
-            lDummy.setForeground(buttonFG);
-            lDummy.setFont(font);               constraints.weightx = 0.15;
-            constraints.gridx = 4;
+            JLabel lIdCode = new JLabel(planeMarkingManager.determineDisplayMarkings(campaign, plane), JLabel.RIGHT);
+            lIdCode.setOpaque(false);
+            lIdCode.setForeground(buttonFG);
+            lIdCode.setFont(font);               constraints.weightx = 0.15;
+            constraints.gridx = 3;
             constraints.gridy = i;
-            equipmentChalkboardPanel.add(lDummy, constraints);
+            equipmentChalkboardPanel.add(lIdCode, constraints);
              
             lDummy = new JLabel("     ");
             lDummy.setOpaque(false);

--- a/src/main/java/pwcg/gui/campaign/intel/CampaignIntelligenceBase.java
+++ b/src/main/java/pwcg/gui/campaign/intel/CampaignIntelligenceBase.java
@@ -241,7 +241,7 @@ public abstract class CampaignIntelligenceBase extends JPanel implements ActionL
         for (int i = 0; i < sortedAircraftOnInventory.size(); ++i)
         {
             EquippedPlane plane = sortedAircraftOnInventory.get(i);
-            intelBuffer.append("    " + plane.getDisplayName() + " (" + plane.getSerialNumber() + ")");
+            intelBuffer.append("    " + plane.getDisplayName() + " (" + plane.getDisplayMarkings() + ")");
             intelBuffer.append(".\n");          
         }
     }

--- a/src/main/java/pwcg/gui/display/model/CombatReportBuilder.java
+++ b/src/main/java/pwcg/gui/display/model/CombatReportBuilder.java
@@ -166,7 +166,7 @@ public class CombatReportBuilder
         for (PlaneStatusEvent planeLostEvent :squadronPlanesLostInMission.values())
         {
             EquippedPlane lostPlane = campaign.getEquipmentManager().getAnyPlaneWithPreference(planeLostEvent.getPlaneSerialNumber());
-            planesLostAppend += "    " + lostPlane.getDisplayName() + ": " + lostPlane.getSerialNumber() + "\n";
+            planesLostAppend += "    " + lostPlane.getDisplayName() + ": " + lostPlane.getDisplayMarkings() + "\n";
         }
         
         if (planesLostAppend.length() > 0)

--- a/src/main/java/pwcg/gui/rofmap/brief/BriefingMapSquadronSelector.java
+++ b/src/main/java/pwcg/gui/rofmap/brief/BriefingMapSquadronSelector.java
@@ -111,7 +111,7 @@ public class BriefingMapSquadronSelector implements ActionListener
     {
         try
         {
-            int squadronId = new Integer(ae.getActionCommand());
+            int squadronId = Integer.parseInt(ae.getActionCommand());
             if (squadronId == ALL_SQUADRONS)
             {
                 for (JCheckBox checkBox : squadronCheckBoxes.values())

--- a/src/main/java/pwcg/gui/rofmap/brief/BriefingPilotChalkboard.java
+++ b/src/main/java/pwcg/gui/rofmap/brief/BriefingPilotChalkboard.java
@@ -190,7 +190,7 @@ public class BriefingPilotChalkboard extends ImageResizingPanel
 
     private void addPlaneColumn(JPanel assignedPilotPanel, CrewPlanePayloadPairing crewPlane, int row) throws PWCGException
     {
-        String planeName = crewPlane.getPlane().getDisplayName() + " (" + crewPlane.getPlane().getSerialNumber() + ")";
+        String planeName = crewPlane.getPlane().getDisplayName() + " (" + crewPlane.getPlane().getDisplayMarkings() + ")";
         JButton planeButton = PWCGButtonFactory.makeBriefingChalkBoardButton(planeName, 
                 "Change Plane:" + crewPlane.getPilot().getSerialNumber(), "Change aircraft for  " + crewPlane.getPilot().getNameAndRank(), parent);
         planeButton.setVerticalAlignment(SwingConstants.TOP);
@@ -291,7 +291,7 @@ public class BriefingPilotChalkboard extends ImageResizingPanel
             if (sortedUnassignedPlanes.size() > i)
             {
                 EquippedPlane unassignedPlane = sortedUnassignedPlanes.get(i);
-                String planeNameText = unassignedPlane.getDisplayName() + " (" + unassignedPlane.getSerialNumber() + ")";
+                String planeNameText = unassignedPlane.getDisplayName() + " (" + unassignedPlane.getDisplayMarkings() + ")";
                 JLabel planeLabel = PWCGButtonFactory.makeBriefingChalkBoardLabel(planeNameText);
                 unassignedPilotGrid.add(planeLabel);
             }

--- a/src/main/java/pwcg/gui/rofmap/brief/BriefingPilotSelectionScreen.java
+++ b/src/main/java/pwcg/gui/rofmap/brief/BriefingPilotSelectionScreen.java
@@ -233,14 +233,9 @@ public class BriefingPilotSelectionScreen extends ImageResizingPanel implements 
             Integer pilotSerialNumber = getPilotSerialNumberFromAction(action);
 
             BriefingPlanePicker briefingPlanePicker = new BriefingPlanePicker(briefingMissionHandler, this);
-            String newPlaneChoice = briefingPlanePicker.pickPlane(pilotSerialNumber);
-            if (newPlaneChoice != null)
+            Integer planeSerialNumber = briefingPlanePicker.pickPlane(pilotSerialNumber);
+            if (planeSerialNumber != null)
             {
-                int index = newPlaneChoice.indexOf(":");
-                index += 2;
-                String planeSerialNumberString = newPlaneChoice.substring(index);
-                Integer planeSerialNumber = Integer.valueOf(planeSerialNumberString);
-
                 briefingMissionHandler.changePlane(pilotSerialNumber, planeSerialNumber);
             }
 

--- a/src/main/java/pwcg/gui/rofmap/brief/BriefingPlanePicker.java
+++ b/src/main/java/pwcg/gui/rofmap/brief/BriefingPlanePicker.java
@@ -20,26 +20,42 @@ public class BriefingPlanePicker
         this.parent = parent;
     }
 
-    public String pickPlane(Integer pilotSerialNumber) throws PWCGException 
+    public Integer pickPlane(Integer pilotSerialNumber) throws PWCGException
     {       
         List<EquippedPlane> squadronPlanes = missionEditHandler.getSortedUnassignedPlanes();
         Object[] possibilities = new Object[squadronPlanes.size()];
         for (int i = 0; i < squadronPlanes.size(); ++i)
         {
             EquippedPlane plane = squadronPlanes.get(i);
-            String planeSelectionString = plane.getDisplayName() + " : " + plane.getSerialNumber();
-            possibilities[i] = (Object)planeSelectionString;
+            PickerEntry entry = new PickerEntry();
+            entry.description = plane.getDisplayName() + " (" + plane.getDisplayMarkings() + ")";
+            entry.plane = plane;
+            possibilities[i] = entry;
         }
         
-        String pickedPlane = (String)JOptionPane.showInputDialog(
+        PickerEntry pickedPlane = (PickerEntry)JOptionPane.showInputDialog(
                 parent, 
                 "Select Plane", 
                 "Select Plane", 
                 JOptionPane.PLAIN_MESSAGE, 
                 null, 
                 possibilities, 
-                "");
+                null);
         
-        return pickedPlane;
+        if (pickedPlane != null)
+            return pickedPlane.plane.getSerialNumber();
+
+        return null;
     }    
+
+    private static class PickerEntry
+    {
+        public String description;
+        public EquippedPlane plane;
+
+        public String toString()
+        {
+            return description;
+        }
+    }
 }

--- a/src/main/java/pwcg/gui/rofmap/brief/WaypointEditor.java
+++ b/src/main/java/pwcg/gui/rofmap/brief/WaypointEditor.java
@@ -77,12 +77,12 @@ public class WaypointEditor
 
     public int getAltitudeValue()
     {
-        return new Integer(altitudeTextField.getText());
+        return Integer.parseInt(altitudeTextField.getText());
     }
 
     public int getCruisingSpeedValue()
     {
-        return new Integer(cruisingSpeedTextField.getText());
+        return Integer.parseInt(cruisingSpeedTextField.getText());
     }
 
     public void setEnabled(boolean enabled)

--- a/src/main/java/pwcg/mission/flight/plane/PlaneMcu.java
+++ b/src/main/java/pwcg/mission/flight/plane/PlaneMcu.java
@@ -338,6 +338,12 @@ public class PlaneMcu extends EquippedPlane implements Cloneable
             writer.write("  WMMask = " + payload.generateFullModificationMask() + ";");
             writer.newLine();
 
+            if (skin == null || skin.isUseTacticalCodes())
+            {
+                Campaign campaign = PWCGContext.getInstance().getCampaign();
+                PWCGContext.getInstance().getPlaneMarkingManager().writeTacticalCodes(writer, campaign, this);
+            }
+
             writer.write("}");
             writer.newLine();
             writer.newLine();

--- a/src/main/java/pwcg/mission/flight/plot/FlightPathToWaypointPlotter.java
+++ b/src/main/java/pwcg/mission/flight/plot/FlightPathToWaypointPlotter.java
@@ -25,7 +25,7 @@ public class FlightPathToWaypointPlotter
         
         double totalDistance = calculateTotalDistanceToRequestedAction(requestedAction);
         Double timeInHours = (totalDistance / 1000) / flight.getFlightCruisingSpeed();
-        int timeInSeconds = new Double(timeInHours * 60 * 60).intValue();
+        int timeInSeconds = Double.valueOf(timeInHours * 60 * 60).intValue();
         return timeInSeconds;
     }
 

--- a/src/main/java/pwcg/mission/flight/waypoint/patterns/PathAlongFrontDataBuilder.java
+++ b/src/main/java/pwcg/mission/flight/waypoint/patterns/PathAlongFrontDataBuilder.java
@@ -47,7 +47,7 @@ public class PathAlongFrontDataBuilder
     private int adjustPatrolDistanceForAircraftRange(int patrolDistance)
     {
         double planeRange = flight.getFlightPlanes().getFlightLeader().getRange();
-        int maxPatrolRangeForPlane = new Double(planeRange * 0.67).intValue();
+        int maxPatrolRangeForPlane = Double.valueOf(planeRange * 0.67).intValue();
         maxPatrolRangeForPlane *= 1000;
         if (maxPatrolRangeForPlane  < patrolDistance)
         {
@@ -61,7 +61,7 @@ public class PathAlongFrontDataBuilder
     {
         if (determineHasReturnLeg())
         {
-            Double patrolDistanceDouble = new Integer(patrolDistance).doubleValue();
+            Double patrolDistanceDouble = Integer.valueOf(patrolDistance).doubleValue();
             patrolDistanceDouble = patrolDistanceDouble * 0.67;
             return patrolDistanceDouble.intValue();
         }

--- a/src/main/java/pwcg/product/bos/country/BoSServiceManager.java
+++ b/src/main/java/pwcg/product/bos/country/BoSServiceManager.java
@@ -406,7 +406,7 @@ public class BoSServiceManager extends ArmedServiceManager implements IArmedServ
         if (squadronIdString.length() >= 3)
         {
             String countryCodeString = squadronIdString.substring(0,3);
-            Integer countryCode = new Integer(countryCodeString);
+            Integer countryCode = Integer.valueOf(countryCodeString);
             ICountry country = CountryFactory.makeCountryByCode(countryCode);
     
             return getPrimaryServiceForNation(country.getCountry(), date);

--- a/src/main/java/pwcg/product/bos/plane/BoSPlaneMarkingManager.java
+++ b/src/main/java/pwcg/product/bos/plane/BoSPlaneMarkingManager.java
@@ -1,0 +1,93 @@
+package pwcg.product.bos.plane;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import pwcg.campaign.Campaign;
+import pwcg.campaign.context.PWCGContext;
+import pwcg.campaign.plane.Equipment;
+import pwcg.campaign.plane.EquippedPlane;
+import pwcg.campaign.plane.IPlaneMarkingManager;
+import pwcg.campaign.squadron.Squadron;
+import pwcg.core.exception.PWCGException;
+import pwcg.core.utils.RandomNumberGenerator;
+import pwcg.product.bos.country.BoSServiceManager;
+
+public class BoSPlaneMarkingManager implements IPlaneMarkingManager
+{
+
+    @Override
+    public void allocatePlaneIdCode(Campaign campaign, int squadronId, Equipment equipment, EquippedPlane equippedPlane) throws PWCGException
+    {
+        Squadron squadron = PWCGContext.getInstance().getSquadronManager().getSquadron(squadronId);
+
+        Set<String> allocatedCodes = new HashSet<>();
+        for (EquippedPlane plane : equipment.getActiveEquippedPlanes().values())
+        {
+            allocatedCodes.add(plane.getAircraftIdCode());
+        }
+
+        if (squadron.getService() == BoSServiceManager.LUFTWAFFE)
+        {
+            if (squadron.determineDisplayName(campaign.getDate()).contains("JG") ||
+                (squadron.determineDisplayName(campaign.getDate()).contains("SG") &&
+                 squadron.determineUnitIdCode(campaign.getDate()) == null))
+            {
+                // Allocate numbers 1-N
+                int code = 1;
+                while (allocatedCodes.contains(Integer.toString(code)))
+                    code++;
+
+                equippedPlane.setAircraftIdCode(Integer.toString(code));
+            } else {
+                // Allocate letters from A
+                // Do this randomly rather than in sequence?
+                char code = 'A';
+                while (allocatedCodes.contains(Character.toString(code)))
+                    code++;
+                if (code > 'Z')
+                    throw new PWCGException("Unable to allocate plane ID code for squadron " + squadron.getSquadronId());
+
+                equippedPlane.setAircraftIdCode(Character.toString(code));
+            }
+        }
+        else if (squadron.getService() == BoSServiceManager.VVS ||
+                 squadron.getService() == BoSServiceManager.NORMANDIE)
+        {
+            // Random numbers 1-99
+            int code = RandomNumberGenerator.getRandom(99);
+            while (allocatedCodes.contains(Integer.toString(code + 1)))
+                code = (code + 1) % 99;
+
+            equippedPlane.setAircraftIdCode(Integer.toString(code + 1));
+        }
+        else if (squadron.getService() == BoSServiceManager.REGIA_AERONAUTICA)
+        {
+            // Allocate numbers 1-N
+            int code = 1;
+            while (allocatedCodes.contains(Integer.toString(code)))
+                code++;
+
+            equippedPlane.setAircraftIdCode(Integer.toString(code));
+        }
+        else if (squadron.getService() == BoSServiceManager.USAAF ||
+                 squadron.getService() == BoSServiceManager.RAF ||
+                 squadron.getService() == BoSServiceManager.FREE_FRENCH)
+        {
+            // Allocate letters randomly
+            char startCode = (char) ('A' + RandomNumberGenerator.getRandom(25));
+            char code = startCode;
+            while (allocatedCodes.contains(Character.toString(code)))
+            {
+                if (code == 'Z')
+                    code = 'A';
+                else
+                    code++;
+                if (code == startCode)
+                    throw new PWCGException("Unable to allocate plane ID code for squadron " + squadron.getSquadronId());
+            }
+
+            equippedPlane.setAircraftIdCode(Character.toString(code));
+        }
+    }
+}

--- a/src/main/java/pwcg/product/bos/plane/BoSPlaneMarkingManager.java
+++ b/src/main/java/pwcg/product/bos/plane/BoSPlaneMarkingManager.java
@@ -90,4 +90,42 @@ public class BoSPlaneMarkingManager implements IPlaneMarkingManager
             equippedPlane.setAircraftIdCode(Character.toString(code));
         }
     }
+
+    @Override
+    public String determineDisplayMarkings(Campaign campaign, EquippedPlane equippedPlane) throws PWCGException
+    {
+        Squadron squadron = PWCGContext.getInstance().getSquadronManager().getSquadron(equippedPlane.getSquadronId());
+
+        if (squadron.getService() == BoSServiceManager.LUFTWAFFE)
+        {
+            if (squadron.determineDisplayName(campaign.getDate()).contains("JG") ||
+                squadron.determineDisplayName(campaign.getDate()).contains("Sch.G") ||
+                (squadron.determineDisplayName(campaign.getDate()).contains("SG") &&
+                 squadron.determineUnitIdCode(campaign.getDate()) == null))
+            {
+                return equippedPlane.getAircraftIdCode() + "+" + squadron.determineSubUnitIdCode(campaign.getDate());
+            } else {
+                return squadron.determineUnitIdCode(campaign.getDate()) +
+                        "+" +
+                        equippedPlane.getAircraftIdCode() +
+                        squadron.determineSubUnitIdCode(campaign.getDate());
+            }
+        }
+        else if (squadron.getService() == BoSServiceManager.VVS ||
+                 squadron.getService() == BoSServiceManager.NORMANDIE)
+        {
+            return equippedPlane.getAircraftIdCode();
+        }
+        else if (squadron.getService() == BoSServiceManager.REGIA_AERONAUTICA ||
+                 squadron.getService() == BoSServiceManager.USAAF ||
+                 squadron.getService() == BoSServiceManager.RAF ||
+                 squadron.getService() == BoSServiceManager.FREE_FRENCH)
+        {
+            return squadron.determineUnitIdCode(campaign.getDate()) +
+                    "-" +
+                    equippedPlane.getAircraftIdCode();
+        }
+
+        return Integer.toString(equippedPlane.getSerialNumber());
+    }
 }

--- a/src/main/java/pwcg/product/bos/plane/BoSPlaneMarkingManager.java
+++ b/src/main/java/pwcg/product/bos/plane/BoSPlaneMarkingManager.java
@@ -1,5 +1,8 @@
 package pwcg.product.bos.plane;
 
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.net.URLEncoder;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -8,9 +11,13 @@ import pwcg.campaign.context.PWCGContext;
 import pwcg.campaign.plane.Equipment;
 import pwcg.campaign.plane.EquippedPlane;
 import pwcg.campaign.plane.IPlaneMarkingManager;
+import pwcg.campaign.skin.TacticalCodeColor;
 import pwcg.campaign.squadron.Squadron;
 import pwcg.core.exception.PWCGException;
+import pwcg.core.exception.PWCGIOException;
+import pwcg.core.utils.PWCGLogger;
 import pwcg.core.utils.RandomNumberGenerator;
+import pwcg.mission.flight.plane.PlaneMcu;
 import pwcg.product.bos.country.BoSServiceManager;
 
 public class BoSPlaneMarkingManager implements IPlaneMarkingManager
@@ -127,5 +134,94 @@ public class BoSPlaneMarkingManager implements IPlaneMarkingManager
         }
 
         return Integer.toString(equippedPlane.getSerialNumber());
+    }
+
+    private String convertGerman(String in)
+    {
+        String str = in;
+        str = str.replace("<<-", "\"\u0027");
+        str = str.replace("<<", "\"");
+        str = str.replace("<-", "\u0021\u0027");
+        str = str.replace("<", "\u0021");
+        str = str.replace("\u25cb|", "\u0024"); // Open circle followed by bar
+        str = str.replace("\u25cb", "\u0023");  // Open circle
+        str = str.replace("||", "\u0026");
+        str = str.replace("|", "\u0025");
+        str = str.replace("\u25b2", "\u0028");  // Solid triangle
+        str = str.replace("\u25cb", "\u003a");  // Solid circle
+        str = str.replace("-", "\u003b");
+        str = str.replace("+", "\u003c");
+        str = str.replace("~~", "\u003e");
+        str = str.replace("~", "\u003d");
+        return str;
+    }
+
+    @Override
+    public void writeTacticalCodes(BufferedWriter writer, Campaign campaign, PlaneMcu planeMcu) throws PWCGException
+    {
+        Squadron squadron = PWCGContext.getInstance().getSquadronManager().getSquadron(planeMcu.getSquadronId());
+        String tCode = null;
+        String tCodeColor = null;
+
+        TacticalCodeColor tacticalCodeColor = planeMcu.getTacticalCodeColor();
+        if (planeMcu.getSkin() != null)
+        {
+            tacticalCodeColor = planeMcu.getSkin().getTacticalCodeColor();
+        }
+
+        if (squadron.getService() == BoSServiceManager.LUFTWAFFE)
+        {
+            if (squadron.determineDisplayName(campaign.getDate()).contains("JG") ||
+                squadron.determineDisplayName(campaign.getDate()).contains("Sch.G") ||
+                (squadron.determineDisplayName(campaign.getDate()).contains("SG") &&
+                 squadron.determineUnitIdCode(campaign.getDate()) == null))
+            {
+                tCode = String.format("%2s%-2s",
+                                      convertGerman(planeMcu.getAircraftIdCode()),
+                                      convertGerman(squadron.determineSubUnitIdCode(campaign.getDate())));
+                tCodeColor = String.format("%1$s%1$s%1$s%1$s", tacticalCodeColor.getColorCode());
+            } else {
+                tCode = String.format("%2s%s%s",
+                                      convertGerman(squadron.determineUnitIdCode(campaign.getDate())),
+                                      convertGerman(planeMcu.getAircraftIdCode()),
+                                      convertGerman(squadron.determineSubUnitIdCode(campaign.getDate())));
+                tCodeColor = String.format("%1$s%1$s%1$s%1$s", tacticalCodeColor.getColorCode());
+            }
+        }
+        else if (squadron.getService() == BoSServiceManager.VVS ||
+                 squadron.getService() == BoSServiceManager.NORMANDIE)
+        {
+            tCode = String.format("%-4s", planeMcu.getAircraftIdCode());
+            tCodeColor = String.format("%1$s%1$s%1$s%1$s", tacticalCodeColor.getColorCode());
+        }
+        else if (squadron.getService() == BoSServiceManager.USAAF ||
+                 squadron.getService() == BoSServiceManager.RAF ||
+                 squadron.getService() == BoSServiceManager.FREE_FRENCH)
+        {
+            tCode = String.format("%2s%s",
+                                  squadron.determineUnitIdCode(campaign.getDate()),
+                                  planeMcu.getAircraftIdCode());
+            tCodeColor = String.format("%1$s%1$s%1$s", tacticalCodeColor.getColorCode());
+        }
+        else if (squadron.getService() == BoSServiceManager.REGIA_AERONAUTICA)
+        {
+            tCode = String.format("%3s%-2s",
+                                  squadron.determineUnitIdCode(campaign.getDate()),
+                                  planeMcu.getAircraftIdCode());
+            tCodeColor = String.format("%1$s%1$s%1$s%1$s%1$s", tacticalCodeColor.getColorCode());
+        }
+
+        if (tCode != null)
+        {
+            try {
+                writer.write("  TCode = \"" + URLEncoder.encode(tCode, "UTF-8").replace("+",  "%20") + "\";");
+                writer.newLine();
+                writer.write("  TCodeColor = \"" + tCodeColor + "\";");
+                writer.newLine();
+            } catch (IOException e) {
+                PWCGLogger.logException(e);
+                throw new PWCGIOException(e.getMessage());
+            }
+        }
     }
 }

--- a/src/main/java/pwcg/product/fc/country/FCServiceManager.java
+++ b/src/main/java/pwcg/product/fc/country/FCServiceManager.java
@@ -430,7 +430,7 @@ public class FCServiceManager extends ArmedServiceManager implements IArmedServi
     {
         String squadronIdString = "" + squadronId;
         String countryCodeString = squadronIdString.substring(0,3);
-        Integer countryCode = new Integer(countryCodeString);
+        Integer countryCode = Integer.valueOf(countryCodeString);
         ICountry country = CountryFactory.makeCountryByCode(countryCode);
     
         return getPrimaryServiceForNation(country.getCountry(), date);

--- a/src/test/java/pwcg/aar/awards/PromotionEventHandlerReconTest.java
+++ b/src/test/java/pwcg/aar/awards/PromotionEventHandlerReconTest.java
@@ -10,8 +10,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import pwcg.aar.awards.PromotionEventHandler;
-import pwcg.aar.awards.PromotionEventHandlerRecon;
 import pwcg.campaign.ArmedService;
 import pwcg.campaign.Campaign;
 import pwcg.campaign.context.PWCGContext;

--- a/src/test/java/pwcg/aar/inmission/phase2/logeval/victory/AARAreaOfCombatTest.java
+++ b/src/test/java/pwcg/aar/inmission/phase2/logeval/victory/AARAreaOfCombatTest.java
@@ -8,7 +8,6 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import pwcg.aar.inmission.phase2.logeval.missionresultentity.LogVictory;
-import pwcg.aar.inmission.phase2.logeval.victory.AARAreaOfCombat;
 import pwcg.core.exception.PWCGException;
 import pwcg.core.location.Coordinate;
 

--- a/src/test/java/pwcg/aar/inmission/phase2/logeval/victory/AARFuzzyVictoryEvaluatorTest.java
+++ b/src/test/java/pwcg/aar/inmission/phase2/logeval/victory/AARFuzzyVictoryEvaluatorTest.java
@@ -12,9 +12,6 @@ import pwcg.aar.inmission.phase2.logeval.AARVehicleBuilder;
 import pwcg.aar.inmission.phase2.logeval.missionresultentity.LogUnknown;
 import pwcg.aar.inmission.phase2.logeval.missionresultentity.LogPlane;
 import pwcg.aar.inmission.phase2.logeval.missionresultentity.LogVictory;
-import pwcg.aar.inmission.phase2.logeval.victory.AARFuzzyByAccumulatedDamaged;
-import pwcg.aar.inmission.phase2.logeval.victory.AARFuzzyVictoryEvaluator;
-import pwcg.aar.inmission.phase2.logeval.victory.AARRandomAssignment;
 import pwcg.core.exception.PWCGException;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/pwcg/campaign/context/AceManagerTest.java
+++ b/src/test/java/pwcg/campaign/context/AceManagerTest.java
@@ -15,7 +15,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import pwcg.campaign.Campaign;
 import pwcg.campaign.CampaignAces;
 import pwcg.campaign.CampaignPersonnelManager;
-import pwcg.campaign.context.FrontMapIdentifier;
 import pwcg.campaign.personnel.SquadronPersonnel;
 import pwcg.campaign.squadmember.Ace;
 import pwcg.campaign.squadmember.HistoricalAce;

--- a/src/test/java/pwcg/campaign/context/BehindEnemyLinesTest.java
+++ b/src/test/java/pwcg/campaign/context/BehindEnemyLinesTest.java
@@ -6,7 +6,6 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import pwcg.campaign.api.Side;
-import pwcg.campaign.context.FrontMapIdentifier;
 import pwcg.core.exception.PWCGException;
 import pwcg.core.location.Coordinate;
 import pwcg.core.utils.DateUtils;

--- a/src/test/java/pwcg/product/bos/plane/payload/BoSPayloadFactoryTest.java
+++ b/src/test/java/pwcg/product/bos/plane/payload/BoSPayloadFactoryTest.java
@@ -13,7 +13,6 @@ import pwcg.campaign.plane.payload.IPlanePayload;
 import pwcg.campaign.plane.payload.PayloadElement;
 import pwcg.core.exception.PWCGException;
 import pwcg.product.bos.plane.BosPlaneAttributeMapping;
-import pwcg.product.bos.plane.payload.BoSPayloadFactory;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BoSPayloadFactoryTest


### PR DESCRIPTION
Generates tactical codes for planes, based on historical unit IDs, and adds these to the mission files to be rendered in-game.

Individual skins need to be flagged to allow tactical codes to be applied (it's assumed that the default skin always can).

Codes are generated for all aircraft in the campaign, but are only available in-game for P-51.