### PR TITLE
Fix the model path for various planes.

### DIFF
--- a/BoSData/Input/Aircraft/fw190d9.json
+++ b/BoSData/Input/Aircraft/fw190d9.json
@@ -11,7 +11,7 @@
 	],
 	"displayName": "Fw 190 D-9",
 	"script": "LuaScripts\\WorldObjects\\Planes\\fw190d9.txt",
-	"model": "graphics\\planes\\fw190a8\\fw190d9.mgm",
+	"model": "graphics\\planes\\fw190d9\\fw190d9.mgm",
 	"desc": "",
 	"cruisingSpeed": 360,
 	"climbOutRate": 1100,

--- a/BoSData/Input/Aircraft/me262a.json
+++ b/BoSData/Input/Aircraft/me262a.json
@@ -12,7 +12,7 @@
 	],
 	"displayName": "Me 262 A",
 	"script": "LuaScripts\\WorldObjects\\Planes\\me262a.txt",
-	"model": "graphics\\planes\\fw190a3\\me262a.mgm",
+	"model": "graphics\\planes\\me262a\\me262a.mgm",
 	"desc": "",
 	"cruisingSpeed": 430,
 	"climbOutRate": 1100,

--- a/BoSData/Input/Aircraft/spitfiremkxiv.json
+++ b/BoSData/Input/Aircraft/spitfiremkxiv.json
@@ -11,7 +11,7 @@
 	],
 	"displayName": "Spitfire Mk.XIV",
 	"script": "LuaScripts\\WorldObjects\\Planes\\spitfiremkxiv.txt",
-	"model": "graphics\\planes\\spitfiremkixe\\spitfiremkxiv.mgm",
+	"model": "graphics\\planes\\spitfiremkxiv\\spitfiremkxiv.mgm",
 	"desc": "",
 	"cruisingSpeed": 380,
 	"climbOutRate": 2000,

--- a/BoSData/Input/Aircraft/spitfiremkxive.json
+++ b/BoSData/Input/Aircraft/spitfiremkxive.json
@@ -10,7 +10,7 @@
 	],
 	"displayName": "Spitfire Mk.XIVe",
 	"script": "LuaScripts\\WorldObjects\\Planes\\spitfiremkxive.txt",
-	"model": "graphics\\planes\\spitfiremkixe\\spitfiremkxive.mgm",
+	"model": "graphics\\planes\\spitfiremkxive\\spitfiremkxive.mgm",
 	"desc": "",
 	"cruisingSpeed": 380,
 	"climbOutRate": 2000,

--- a/BoSData/Input/Aircraft/yak9s1.json
+++ b/BoSData/Input/Aircraft/yak9s1.json
@@ -12,7 +12,7 @@
 	],
 	"displayName": "Yak-9 ser.1",
 	"script": "LuaScripts\\WorldObjects\\Planes\\yak9s1.txt",
-	"model": "graphics\\planes\\yak7bs36\\yak9s1.mgm",
+	"model": "graphics\\planes\\yak9s1\\yak9s1.mgm",
 	"desc": "",
 	"cruisingSpeed": 350,
 	"climbOutRate": 1300,

--- a/BoSData/Input/Aircraft/yak9ts1.json
+++ b/BoSData/Input/Aircraft/yak9ts1.json
@@ -13,7 +13,7 @@
 	],
 	"displayName": "Yak-9T ser.1",
 	"script": "LuaScripts\\WorldObjects\\Planes\\yak9ts1.txt",
-	"model": "graphics\\planes\\yak7bs36\\yak9ts1.mgm",
+	"model": "graphics\\planes\\yak9ts1\\yak9ts1.mgm",
 	"desc": "",
 	"cruisingSpeed": 350,
 	"climbOutRate": 1300,


### PR DESCRIPTION
The sim actually seems to accept these errors without complaint, although it still seems correct to fix them.

Found with `cat * | grep model | grep -v -E '\\\\([^\\]*)\\\\\1\.mgm'`